### PR TITLE
issues/36 - Fix request mapping template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,4 +24,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
     - Issue 18 - Remove Flask
 ### Fixed
+    - Issue 36 - Request mapping template was not transforming request parameters correctly resulting in 500 internal server errors
 ### Security

--- a/hydrocron/api/controllers/timeseries.py
+++ b/hydrocron/api/controllers/timeseries.py
@@ -96,7 +96,8 @@ def format_json(results: Generator, feature_id, start_time, end_time, exact, dat
         for t in results:
             # TODO: Coordinate to filter in the database instance:
             # if t['reach_id'] == feature_id and t['time'] > start_time and t['time'] < end_time and t['time'] != '-999999999999':  # and (t['width'] != '-999999999999')):
-            if t['reach_id'] == feature_id and t[constants.FIELDNAME_TIME] != '-999999999999':  # and (t['width'] != '-999999999999')):
+            if t['reach_id'] == feature_id and t[
+                constants.FIELDNAME_TIME] != '-999999999999':  # and (t['width'] != '-999999999999')):
                 feature = {'properties': {}, 'geometry': {}, 'type': "Feature"}
                 feature['geometry']['coordinates'] = []
                 feature_type = ''
@@ -120,7 +121,7 @@ def format_json(results: Generator, feature_id, start_time, end_time, exact, dat
                 i += 1
                 feature['properties']['time'] = datetime.fromtimestamp(
                     float(t[constants.FIELDNAME_TIME]) + 946710000).strftime(
-                        "%Y-%m-%d %H:%M:%S")
+                    "%Y-%m-%d %H:%M:%S")
                 feature['properties']['reach_id'] = float(t[constants.FIELDNAME_REACH_ID])
                 feature['properties']['wse'] = float(t[constants.FIELDNAME_WSE])
                 feature['properties']['slope'] = float(t[constants.FIELDNAME_SLOPE])
@@ -192,21 +193,6 @@ def lambda_handler(event, context):  # noqa: E501 # pylint: disable=W0613
 
     results = gettimeseries_get(feature, feature_id, start_time, end_time, output, fields)
 
-    data = {}
-
-    status = "200 OK"
-
-    data['status'] = status
-    data['time'] = str(10) + " ms."
-    data['hits'] = 10
-
-    data['search on'] = {
-        "parameter": "identifier",
-        "exact": "exact",
-        "page_number": 0,
-        "page_size": 20
-    }
-
-    data['results'] = results
+    data = {'status': "200 OK", 'results': results}
 
     return data

--- a/hydrocron/api/controllers/timeseries.py
+++ b/hydrocron/api/controllers/timeseries.py
@@ -96,8 +96,7 @@ def format_json(results: Generator, feature_id, start_time, end_time, exact, dat
         for t in results:
             # TODO: Coordinate to filter in the database instance:
             # if t['reach_id'] == feature_id and t['time'] > start_time and t['time'] < end_time and t['time'] != '-999999999999':  # and (t['width'] != '-999999999999')):
-            if t['reach_id'] == feature_id and t[
-                constants.FIELDNAME_TIME] != '-999999999999':  # and (t['width'] != '-999999999999')):
+            if t['reach_id'] == feature_id and t[constants.FIELDNAME_TIME] != '-999999999999':  # and (t['width'] != '-999999999999')):
                 feature = {'properties': {}, 'geometry': {}, 'type': "Feature"}
                 feature['geometry']['coordinates'] = []
                 feature_type = ''

--- a/terraform/api-specification-templates/hydrocron_aws_api.yml
+++ b/terraform/api-specification-templates/hydrocron_aws_api.yml
@@ -150,14 +150,17 @@ paths:
                 }
         requestTemplates:
           application/json: |-
+            #set($allParams = $input.params())
             {
-              "body": {
-                "exact":"$input.params('exact')",
-                "region": "$input.params('region')",
-                "page_number": "$input.params('page_number')" ,
-                "page_size": "$input.params('page_size')" ,
-                "polygon_format": "$input.params('polygon_format')"
-              }
+            "body" : {
+            #foreach($type in $allParams.keySet())
+                #set($params = $allParams.get($type))
+                #foreach($paramName in $params.keySet())
+                "$paramName" : "$util.escapeJavaScript($params.get($paramName))"
+                    #if($foreach.hasNext),#end
+                #end
+            #end
+            }
             }
         passthroughBehavior: when_no_templates
         httpMethod: POST

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,6 +4,10 @@ provider "aws" {
   ignore_tags {
     key_prefixes = ["gsfc-ngap"]
   }
+
+  default_tags {
+    tags = local.default_tags
+  }
 }
 
 data "aws_caller_identity" "current" {}


### PR DESCRIPTION
Github Issue: Closes #36 

### Description

Request mapping template was not transforming request parameters correctly resulting in 500 internal server errors

### Overview of work done

Updated mapping template to pass through request parameters inside a 'body' dictionary

### Overview of verification done

Unit tests passed

### Overview of integration done

Manually tested against api gateway through AWS console

```
Request

/v1/timeseries?feature=Reach&reach_id=77480300193&start_time=2023-10-20T00:00:00+00:00&end_time=2023-10-30T00:00:00+00:00&output=csv&fields=reach_id,time_str,wse

Latency
259

Status
200

Response body

{"status":"200 OK","time":"10 ms.","hits":10,"search on":{"parameter":"identifier","exact":"exact","page_number":0,"page_size":20},"results":"reach_id,time_str,wse\n77480300193,2023-10-24T00:09:09Z,5672.0592,\n"}

```

## PR checklist:

* [x] Linted
* [x] Updated unit tests
* [x] Updated changelog
* [x] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_