### PR TITLE
Bugfix/issue-44 Load data by invoking a lambda per granule

### DIFF
--- a/terraform/hydrocron-lambda.tf
+++ b/terraform/hydrocron-lambda.tf
@@ -15,6 +15,7 @@ locals {
   ecr_image_tag                    = element(local.ecr_image_name_and_tag, 1)
   timeseries_function_name         = "${local.aws_resource_prefix}-timeseries-lambda"
   load_data_function_name          = "${local.aws_resource_prefix}-load_data-lambda"
+  load_granule_function_name          = "${local.aws_resource_prefix}-load_granule-lambda"
 }
 
 resource aws_ecr_repository "lambda-image-repo" {
@@ -96,4 +97,34 @@ resource "aws_lambda_function" "hydrocron_lambda_load_data" {
       EARTHDATA_PASSWORD = data.aws_ssm_parameter.edl_password.value
     }
   }
+}
+
+
+resource "aws_lambda_function" "hydrocron_lambda_load_granule" {
+  package_type = "Image"
+  image_uri    = "${aws_ecr_repository.lambda-image-repo.repository_url}:${data.aws_ecr_image.lambda_image.image_tag}"
+  image_config {
+    command = ["hydrocron.db.load_data.granule_handler"]
+  }
+  function_name = local.load_granule_function_name
+  role          = aws_iam_role.hydrocron-lambda-load-data-role.arn
+  timeout       = 600
+  memory_size   = 512
+
+  tags = var.default_tags
+  environment {
+    variables = {
+      EARTHDATA_USERNAME = data.aws_ssm_parameter.edl_username.value
+      EARTHDATA_PASSWORD = data.aws_ssm_parameter.edl_password.value
+      GRANULE_LAMBDA_FUNCTION_NAME = aws_lambda_function.hydrocron_lambda_load_granule.function_name
+    }
+  }
+}
+
+resource "aws_lambda_permission" "allow_lambda" {
+  statement_id  = "AllowExecutionFromLambda"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.hydrocron_lambda_load_granule.function_name
+  principal     = "s3.amazonaws.com"
+  source_arn = "${aws_lambda_function.hydrocron_lambda_load_data}"
 }


### PR DESCRIPTION
Github Issue: #44 

The load data lambda function fails after processing one granule. Adding a second lambda that can be invoked async on all granules in the load data query should avoid any timeout/memeory issues that may be causing this

### Overview of work done

Added a second lambda function in terraform and a new lambda handler function in load script. The original lambda function should now invoke the new one for each granule found in the CMR query, allowing them to be loaded async

### Overview of verification done

In progress, opening PR to deploy to SIT to test.

### Overview of integration done

## PR checklist:

* [x] Linted
* [ ] Updated unit tests
* [ ] Updated changelog
* [ ] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_