### PR TITLE
feature/issue-52 Remove partial_f from data columns to obscure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated 
 ### Removed
     - Issue 18 - Remove Flask
+    - Issue 52 - Remove partial_f from data columns to obscure
 ### Fixed
     - Issue 36 - Request mapping template was not transforming request parameters correctly resulting in 500 internal server errors
 ### Security

--- a/hydrocron/utils/constants.py
+++ b/hydrocron/utils/constants.py
@@ -80,7 +80,7 @@ REACH_DATA_COLUMNS = [
     'dschg_gi', 'dschg_gi_u', 'dschg_gisf', 'dschg_gi_q',
     'dschg_q_b', 'dschg_gq_b',
     'reach_q', 'reach_q_b',
-    'dark_frac', 'ice_clim_f', 'ice_dyn_f', 'partial_f', 'n_good_nod',
+    'dark_frac', 'ice_clim_f', 'ice_dyn_f', 'n_good_nod',
     'obs_frac_n', 'xovr_cal_q', 'geoid_hght', 'geoid_slop',
     'solid_tide', 'load_tidef', 'load_tideg', 'pole_tide',
     'dry_trop_c', 'wet_trop_c', 'iono_c', 'xovr_cal_c'
@@ -92,7 +92,7 @@ NODE_DATA_COLUMNS = [
     'area_total', 'area_tot_u', 'area_detct', 'area_det_u', 'area_wse',
     'layovr_val', 'node_dist', 'xtrk_dist',
     'flow_angle', 'node_q', 'node_q_b',
-    'dark_frac', 'ice_clim_f', 'ice_dyn_f', 'partial_f', 'n_good_pix',
+    'dark_frac', 'ice_clim_f', 'ice_dyn_f', 'n_good_pix',
     'xovr_cal_q', 'rdr_sig0', 'rdr_sig0_u', 'rdr_pol',
     'geoid_hght', 'solid_tide', 'load_tidef', 'load_tideg', 'pole_tide',
     'dry_trop_c', 'wet_trop_c', 'iono_c', 'xovr_cal_c'


### PR DESCRIPTION
Github Issue: #52 Remove partial_f from data columns to obscure

### Description

Running the load data script in UAT often fails due to partial_f not being represented consistently in the shapefiles. This field is a flag indicating partial coverage and does not need to be obscured.

### Overview of work done

Removed partial_f from list of fields to obscure

### Overview of verification done

Unit tests pass

### Overview of integration done


## PR checklist:

* [x] Linted
* [x] Updated unit tests
* [x] Updated changelog
* [ ] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_