### PR TITLE
Feature/issue 66

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
     - Issue 75 - Update log messaging format
+    - Issue 60 - Improved error handling
 ### Changed
 ### Deprecated 
 ### Removed

--- a/hydrocron/api/controllers/timeseries.py
+++ b/hydrocron/api/controllers/timeseries.py
@@ -71,8 +71,9 @@ def format_json(feature_lower, results, feature_id, fields):  # noqa: E501 # pyl
     data = {}
     i = 0
 
+    data['error'] = '200 OK'
     if results is None:
-        data['error'] = f"404: Results with the specified Feature ID {feature_id} were not found."
+        data['error'] = f'404: Results with the specified Feature ID {feature_id} were not found.'
     elif len(results) > 5750000:
         data['error'] = f'413: Query exceeds 6MB with {len(results)} hits.'
 
@@ -141,7 +142,7 @@ def format_csv(feature_lower, results, feature_id, fields):  # noqa: E501 # pyli
     csv = fields + '\n'
 
     if results is None:
-        data['error'] = f"404: Results with the specified Feature ID {feature_id} were not found."
+        data['error'] = f'404: Results with the specified Feature ID {feature_id} were not found.'
     elif len(results) > 5750000:
         data['error'] = f'413: Query exceeds 6MB with {len(results)} hits.'
 
@@ -182,17 +183,17 @@ def lambda_handler(event, context):  # noqa: E501 # pylint: disable=W0613
     fields = event['body']['fields']
 
     missing_params = []
-    if feature.isEmpty():
+    if feature == '':
         missing_params.append('Feature')
-    if feature_id.isEmpty():
+    if feature_id == '':
         missing_params.append('Feature ID')
-    if start_time.isEmpty():
+    if start_time == '':
         missing_params.append('Start time')
-    if end_time.isEmpty():
+    if end_time == '':
         missing_params.append('End time')
-    if output.isEmpty():
+    if output == '':
         missing_params.append('Output')
-    if fields.isEmpty():
+    if fields == '':
         missing_params.append('Fields')
 
     if missing_params:
@@ -200,14 +201,14 @@ def lambda_handler(event, context):  # noqa: E501 # pylint: disable=W0613
 
     start = time.time()
     results, hits = timeseries_get(feature, feature_id, start_time, end_time, output, fields)
-    if results['Error'] == '':
-        results['Error'] = error_code
+    if type(results) is dict and results['error'] != '':
+        error_code = results['error']
 
     end = time.time()
     elapsed = round((end - start) * 1000, 3)
     print({"start": start, "end": end, "elapsed": elapsed})
 
-    data = {'status': results['Error'], 'time': elapsed, 'hits': hits, 'results': {'csv': "", 'geojson': {}}}
+    data = {'status': error_code, 'time': elapsed, 'hits': hits, 'results': {'csv': "", 'geojson': {}}}
     data['results'][event['body']['output']] = results
 
     return data

--- a/hydrocron/api/controllers/timeseries.py
+++ b/hydrocron/api/controllers/timeseries.py
@@ -262,6 +262,8 @@ def lambda_handler(event, context):  # noqa: E501 # pylint: disable=W0613
     This function queries the database for relevant results
     """
 
+    print(f"Event - {event}")
+
     feature = event['body']['feature']
     feature_id = event['body']['feature_id']
     start_time = event['body']['start_time']

--- a/hydrocron/api/controllers/timeseries.py
+++ b/hydrocron/api/controllers/timeseries.py
@@ -182,17 +182,17 @@ def lambda_handler(event, context):  # noqa: E501 # pylint: disable=W0613
     fields = event['body']['fields']
 
     any_empty = False
-    if feature == '':
+    if feature.isEmpty():
         any_empty = True
-    if feature_id == '':
+    if feature_id.isEmpty():
         any_empty = True
-    if start_time == '':
+    if start_time.isEmpty():
         any_empty = True
-    if end_time == '':
+    if end_time.isEmpty():
         any_empty = True
-    if output == '':
+    if output.isEmpty():
         any_empty = True
-    if fields == '':
+    if fields.isEmpty():
         any_empty = True
 
     if any_empty:

--- a/hydrocron/api/controllers/timeseries.py
+++ b/hydrocron/api/controllers/timeseries.py
@@ -201,7 +201,7 @@ def lambda_handler(event, context):  # noqa: E501 # pylint: disable=W0613
 
     start = time.time()
     results, hits = timeseries_get(feature, feature_id, start_time, end_time, output, fields)
-    if type(results) is dict and results['error'] != '':
+    if isinstance(results, dict) and results['error'] != '':
         error_code = results['error']
 
     end = time.time()

--- a/hydrocron/api/controllers/timeseries.py
+++ b/hydrocron/api/controllers/timeseries.py
@@ -181,22 +181,22 @@ def lambda_handler(event, context):  # noqa: E501 # pylint: disable=W0613
     output = event['body']['output']
     fields = event['body']['fields']
 
-    any_empty = False
+    missing_params = []
     if feature.isEmpty():
-        any_empty = True
+        missing_params.append('Feature')
     if feature_id.isEmpty():
-        any_empty = True
+        missing_params.append('Feature ID')
     if start_time.isEmpty():
-        any_empty = True
+        missing_params.append('Start time')
     if end_time.isEmpty():
-        any_empty = True
+        missing_params.append('End time')
     if output.isEmpty():
-        any_empty = True
+        missing_params.append('Output')
     if fields.isEmpty():
-        any_empty = True
+        missing_params.append('Fields')
 
-    if any_empty:
-        error_code = '400: All required parameters are missing.'
+    if missing_params:
+        error_code = f'400: These required parameters are missing: {missing_params}'
 
     start = time.time()
     results, hits = timeseries_get(feature, feature_id, start_time, end_time, output, fields)

--- a/hydrocron/api/controllers/timeseries.py
+++ b/hydrocron/api/controllers/timeseries.py
@@ -196,7 +196,7 @@ def lambda_handler(event, context):  # noqa: E501 # pylint: disable=W0613
         any_empty = True
 
     if any_empty:
-        error_code = f'400: All required parameters are missing.'
+        error_code = '400: All required parameters are missing.'
 
     start = time.time()
     results, hits = timeseries_get(feature, feature_id, start_time, end_time, output, fields)

--- a/hydrocron/api/controllers/timeseries.py
+++ b/hydrocron/api/controllers/timeseries.py
@@ -249,6 +249,16 @@ def is_fields_valid(feature, fields):
     return all(field in columns for field in fields)
 
 
+def sanitize_time(start_time, end_time):
+    """
+    Return formatted string to handle cases where request includes non-padded numbers
+    """
+
+    start_time = datetime.datetime.strptime(start_time, "%Y-%m-%dT%H:%M:%S%z").strftime("%Y-%m-%dT%H:%M:%S%z")
+    end_time = datetime.datetime.strptime(end_time, "%Y-%m-%dT%H:%M:%S%z").strftime("%Y-%m-%dT%H:%M:%S%z")
+    return start_time, end_time
+
+
 def lambda_handler(event, context):  # noqa: E501 # pylint: disable=W0613
     """
     This function queries the database for relevant results
@@ -266,6 +276,7 @@ def lambda_handler(event, context):  # noqa: E501 # pylint: disable=W0613
     results, hits = validate_parameters(feature, feature_id, start_time, end_time, output, fields)
 
     if results['error'] == '200 OK':
+        start_time, end_time = sanitize_time(start_time, end_time)
         results, hits = timeseries_get(feature, feature_id, start_time, end_time, output, fields)
 
     end = time.time()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -26,9 +26,8 @@ def test_timeseries_lambda_handler_geojson(hydrocron_api):
 
     context = "_"
     result = hydrocron.api.controllers.timeseries.lambda_handler(event, context)
-    print(result['results']['geojson'])
     assert result['status'] == '200 OK' and \
-           result['results']['geojson'] == {'error': '200 OK', 'type': 'FeatureCollection', 'features': [
+           result['results']['geojson'] == {'type': 'FeatureCollection', 'features': [
                     {'properties': {'reach_id': '71224100223', 'time_str': '2023-06-10T19:39:43Z',
                     'wse': '286.2983'}, 'geometry': {'coordinates':
                     [[-95.564991, 50.223686], [-95.564559, 50.223479],
@@ -327,4 +326,4 @@ def test_timeseries_lambda_handler_csv(hydrocron_api):
                                         '50.288507, -95.537995 50.288775, -95.538093 50.289043, -95.538192 50.28931, ' \
                                         '-95.538206 50.28958, -95.538221 50.289849, -95.538235 50.290119, -95.538334 ' \
                                         '50.290387, -95.538432 50.290654, -95.538531 50.290922, -95.538629 ' \
-                                        '50.29119),\n')
+                                        '50.29119)\n')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -338,20 +338,23 @@ def test_timeseries_lambda_handler_missing(hydrocron_api):
     """
     import hydrocron.api.controllers.timeseries
 
+    event = {"body": {}}
+    context = "_"
+    result = hydrocron.api.controllers.timeseries.lambda_handler(event, context)
+    assert result['status'] == "400: This required parameter is missing: 'feature'"
+
     event = {
         "body": {
-            "feature": "",
-            "feature_id": "",
+            "feature": "Reach",
             "start_time": "2023-06-04T00:00:00Z",
             "end_time": "2023-06-23T00:00:00Z",
-            "output": "",
+            "output": "geojson",
             "fields": "reach_id,time_str,wse,geometry"
         }
     }
-
     context = "_"
     result = hydrocron.api.controllers.timeseries.lambda_handler(event, context)
-    assert result['status'] == "400: These required parameters are missing: ['Feature', 'Feature ID', 'Output']"
+    assert result['status'] == "400: This required parameter is missing: 'feature_id'"
 
 
 def test_timeseries_lambda_handler_feature(hydrocron_api):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -327,3 +327,154 @@ def test_timeseries_lambda_handler_csv(hydrocron_api):
                                         '-95.538206 50.28958, -95.538221 50.289849, -95.538235 50.290119, -95.538334 ' \
                                         '50.290387, -95.538432 50.290654, -95.538531 50.290922, -95.538629 ' \
                                         '50.29119)\n')
+
+
+def test_timeseries_lambda_handler_missing(hydrocron_api):
+    """
+    Test the lambda handler for the timeseries endpoint for missing parameters
+    Parameters
+    ----------
+    hydrocron_api: Fixture ensuring the database is configured for the api
+    """
+    import hydrocron.api.controllers.timeseries
+
+    event = {
+        "body": {
+            "feature": "",
+            "feature_id": "",
+            "start_time": "2023-06-04T00:00:00Z",
+            "end_time": "2023-06-23T00:00:00Z",
+            "output": "",
+            "fields": "reach_id,time_str,wse,geometry"
+        }
+    }
+
+    context = "_"
+    result = hydrocron.api.controllers.timeseries.lambda_handler(event, context)
+    assert result['status'] == "400: These required parameters are missing: ['Feature', 'Feature ID', 'Output']"
+
+
+def test_timeseries_lambda_handler_feature(hydrocron_api):
+    """
+    Test the lambda handler for the timeseries endpoint for feature parameter
+    Parameters
+    ----------
+    hydrocron_api: Fixture ensuring the database is configured for the api
+    """
+    import hydrocron.api.controllers.timeseries
+
+    event = {
+        "body": {
+            "feature": "River",
+            "feature_id": "71224100223",
+            "start_time": "2023-06-04T00:00:00Z",
+            "end_time": "2023-06-23T00:00:00Z",
+            "output": "geojson",
+            "fields": "reach_id,time_str,wse,geometry"
+        }
+    }
+
+    context = "_"
+    result = hydrocron.api.controllers.timeseries.lambda_handler(event, context)
+    assert result['status'] == "400: feature parameter should be Reach or Node, not: River"
+
+
+def test_timeseries_lambda_handler_feature_id(hydrocron_api):
+    """
+    Test the lambda handler for the timeseries endpoint for feature_id parameter
+    Parameters
+    ----------
+    hydrocron_api: Fixture ensuring the database is configured for the api
+    """
+    import hydrocron.api.controllers.timeseries
+
+    event = {
+        "body": {
+            "feature": "Reach",
+            "feature_id": "7122ff4100223",
+            "start_time": "2023-06-04T00:00:00Z",
+            "end_time": "2023-06-23T00:00:00Z",
+            "output": "geojson",
+            "fields": "reach_id,time_str,wse,geometry"
+        }
+    }
+
+    context = "_"
+    result = hydrocron.api.controllers.timeseries.lambda_handler(event, context)
+    assert result['status'] == "400: feature_id cannot contain letters: 7122ff4100223"
+
+
+def test_timeseries_lambda_handler_dates(hydrocron_api):
+    """
+    Test the lambda handler for the timeseries endpoint for start_time and 
+    end_time parameters
+    Parameters
+    ----------
+    hydrocron_api: Fixture ensuring the database is configured for the api
+    """
+    import hydrocron.api.controllers.timeseries
+
+    event = {
+        "body": {
+            "feature": "Reach",
+            "feature_id": "71224100223",
+            "start_time": "2023/06/04T00:00:00Z",
+            "end_time": "2023-06-23T00:00:00Z",
+            "output": "geojson",
+            "fields": "reach_id,time_str,wse,geometry"
+        }
+    }
+
+    context = "_"
+    result = hydrocron.api.controllers.timeseries.lambda_handler(event, context)
+    assert result['status'] == "400: start_time and end_time parameters must conform to format: YYYY-MM-DDTHH:MM:SS+00:00"
+
+
+def test_timeseries_lambda_handler_output(hydrocron_api):
+    """
+    Test the lambda handler for the timeseries output parameters
+    Parameters
+    ----------
+    hydrocron_api: Fixture ensuring the database is configured for the api
+    """
+    import hydrocron.api.controllers.timeseries
+
+    event = {
+        "body": {
+            "feature": "Reach",
+            "feature_id": "71224100223",
+            "start_time": "2023-06-04T00:00:00Z",
+            "end_time": "2023-06-23T00:00:00Z",
+            "output": "txt",
+            "fields": "reach_id,time_str,wse,geometry"
+        }
+    }
+
+    context = "_"
+    result = hydrocron.api.controllers.timeseries.lambda_handler(event, context)
+    assert result['status'] == "400: output parameter should be csv or geojson, not: txt"
+
+
+def test_timeseries_lambda_handler_fields(hydrocron_api):
+    """
+    Test the lambda handler for the timeseries output parameters
+    Parameters
+    ----------
+    hydrocron_api: Fixture ensuring the database is configured for the api
+    """
+    import hydrocron.api.controllers.timeseries
+
+    event = {
+        "body": {
+            "feature": "Reach",
+            "feature_id": "71224100223",
+            "start_time": "2023-06-04T00:00:00Z",
+            "end_time": "2023-06-23T00:00:00Z",
+            "output": "geojson",
+            "fields": "reach_id,time_str,wse,geometry,height"
+        }
+    }
+
+    context = "_"
+    result = hydrocron.api.controllers.timeseries.lambda_handler(event, context)
+    assert result['status'] == "400: fields parameter should contain valid SWOT fields"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -28,7 +28,7 @@ def test_timeseries_lambda_handler_geojson(hydrocron_api):
     result = hydrocron.api.controllers.timeseries.lambda_handler(event, context)
     print(result['results']['geojson'])
     assert result['status'] == '200 OK' and \
-           result['results']['geojson'] == {'type': 'FeatureCollection', 'features': [
+           result['results']['geojson'] == {'error': '200 OK', 'type': 'FeatureCollection', 'features': [
                     {'properties': {'reach_id': '71224100223', 'time_str': '2023-06-10T19:39:43Z',
                     'wse': '286.2983'}, 'geometry': {'coordinates':
                     [[-95.564991, 50.223686], [-95.564559, 50.223479],


### PR DESCRIPTION
Github Issue: 66

### Description

Improve error handling.

Return a 400 Bad Request response when a user makes a request with missing parameters. Perform some validation on the parameters passed in the request.

### Overview of work done

Modified the timeseries controller to test for missing or invalid request parameters. Basic tests are preformed on the format and content of the parameters before being passed to the database query.

### Overview of verification done

Unit tests were created for potential cases where the request parameters are invalid. These include testing for:

- All missing parameters
- Partial missing parameters
- If the `feature_id` is not 'Reach' or 'Node'
- If the start and end dates are in the proper format
- If output is 'geojson' or 'csv'
- If all items in the fields parameter list are in the SWOT shapefiles

### Overview of integration done

Modifications were deployed and tested in the services SIT account and include the following:

**Missing parameters**

Request:

```bash
curl --location --request GET 'https://soto.podaac.sit.earthdatacloud.nasa.gov/hydrocron/v1/timeseries'
```

Response:

```json
{"status":"400: This required parameter is missing: 'feature'","time":0.044,"hits":0,"results":{"csv":"","geojson":{}}}
```

**Feature is not 'Reach' or 'Node'**

Request:

```bash
curl --location --request GET 'https://soto.podaac.sit.earthdatacloud.nasa.gov/hydrocron/v1/timeseries?feature=River&feature_id=74222400191&output=csv&start_time=2023-07-28T00:00:00Z&end_time=2023-10-24T00:00:00Z&fields=reach_id,time_str,wse,width'
```

Response:

```json
{"status":"400: feature parameter should be Reach or Node, not: River","time":0.047,"hits":0,"results":{"csv":"","geojson":{}}}
```

**Feature ID is not numeric**

Request:

```bash
curl --location --request GET 'https://soto.podaac.sit.earthdatacloud.nasa.gov/hydrocron/v1/timeseries?feature=Reach&feature_id=742224ddddd00191&output=csv&start_time=2023-07-28T00:00:00Z&end_time=2023-10-24T00:00:00Z&fields=reach_id,time_str,wse,width'
```

Response:

```json
{"status":"400: feature parameter should be Reach or Node, not: River","time":0.047,"hits":0,"results":{"csv":"","geojson":{}}}
```

**Start or end date is not in the correct format**

Request:

```bash
curl --location --request GET 'https://soto.podaac.sit.earthdatacloud.nasa.gov/hydrocron/v1/timeseries?feature=Reach&feature_id=74222400191&output=csv&start_time=2023/07/28T00:00:00Z&end_time=2023/10/24T00:00:00Z&fields=reach_id,time_str,wse,width'
```

Response:

```json
{"status":"400: feature_id cannot contain letters: 742224ddddd00191","time":0.046,"hits":0,"results":{"csv":"","geojson":{}}}
```

**Output is not 'geojson' or 'csv'**

Request:

```bash
curl --location --request GET 'https://soto.podaac.sit.earthdatacloud.nasa.gov/hydrocron/v1/timeseries?feature=Reach&feature_id=74222400191&output=txt&start_time=2023-07-28T00:00:00Z&end_time=2023-10-24T00:00:00Z&fields=reach_id,time_str,wse,width'
```

Response:

```json
{"status":"400: output parameter should be csv or geojson, not: txt","time":6.411,"hits":0,"results":{"csv":"","geojson":{}}}
```

**Not all fields are in SWOT shapefiles**

Request:

```bash
curl --location --request GET 'https://soto.podaac.sit.earthdatacloud.nasa.gov/hydrocron/v1/timeseries?feature=Reach&feature_id=74222400191&output=csv&start_time=2023-07-28T00:00:00Z&end_time=2023-10-24T00:00:00Z&fields=reach_id,time_str,wse,width,height'
```

Response:

```json
{"status":"400: fields parameter should contain valid SWOT fields","time":0.159,"hits":0,"results":{"csv":"","geojson":{}}}
```


## PR checklist:

* [ ] Linted
* [ ] Updated unit tests
* [ ] Updated changelog
* [ ] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_