### PR TITLE
Define ignore_changes lifecycle block for resource policy

### DIFF
--- a/terraform/hydrocron-apigw.tf
+++ b/terraform/hydrocron-apigw.tf
@@ -30,6 +30,9 @@ resource "aws_api_gateway_rest_api" "hydrocron-api-gateway" {
 resource "aws_api_gateway_rest_api_policy" "hydrocron-api-gateway-policy" {
   rest_api_id = aws_api_gateway_rest_api.hydrocron-api-gateway.id
   policy      = data.aws_iam_policy_document.apigw-resource-policy.json
+    lifecycle {
+    ignore_changes = [ policy ]
+  }
 }
 
 


### PR DESCRIPTION
Github Issue: [#95](https://github.com/podaac/hydrocron/issues/95)

### Description

We would like access to the NGAP-controlled API resource policy so that we can integrate it into our Terraform and trigger API stage deployment when necessary. However, as a workaround we have implemented the `ignore_changes` meta-argument as documented [here](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#ignore_changes) while we wait to work out the details of the policy.

### Overview of work done

Implemented `ignore_changes` meta-argument on the `aws_api_gateway_rest_api_policy` resource.

### Overview of verification done

No additional unit tests required as modification was made to Terraform. Passes current unit tests.

### Overview of integration done

1. Deployed issue branch to SIT environment and review Terraform logs.
2. Confirmed that policy was not modified in first deployment of GitHub Action workflow.
3. Ran GitHub Action workflow to confirm that resource policy would not be updated or replaced.

Terraform log

```bash
No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration
and found no differences, so no changes are needed.
+ terraform apply -input=false -auto-approve tfplan

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

## PR checklist:

* [X] Linted
* [X] Updated unit tests
* [X] Updated changelog
* [X] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_