### PR TITLE
Feature/issue 105 - Fix load_benchmarking_data flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+    - Issue 105 - Only benchmarking data is being loaded even when load_benchmarking_data flag is false
     - Issue 79 - Generate data for use by benchmarks
     - Issue 88 - There are no CloudWatch logs for the API Gateway
     - Issue 75 - Update log messaging format

--- a/hydrocron/db/load_data.py
+++ b/hydrocron/db/load_data.py
@@ -75,7 +75,9 @@ def granule_handler(event, _):
     table_name = event['body']['table_name']
     load_benchmarking_data = event['body']['load_benchmarking_data']
 
-    if load_benchmarking_data:
+    logging.info("Value of load_benchmarking_data is: %s", load_benchmarking_data)
+
+    if load_benchmarking_data == "True":
         logging.info("Loading benchmarking data")
         items = swot_reach_node_shp.load_benchmarking_data()
     else:

--- a/terraform/hydrocron-dynamo.tf
+++ b/terraform/hydrocron-dynamo.tf
@@ -12,7 +12,6 @@ resource "aws_dynamodb_table" "hydrocron-swot-reach-table" {
     name = "range_start_time"
     type = "S"
   }
-  lifecycle { ignore_changes = [write_capacity, read_capacity] }
 }
 
 module "reach_table_autoscaling" {

--- a/terraform/hydrocron-dynamo.tf
+++ b/terraform/hydrocron-dynamo.tf
@@ -12,6 +12,7 @@ resource "aws_dynamodb_table" "hydrocron-swot-reach-table" {
     name = "range_start_time"
     type = "S"
   }
+  lifecycle { ignore_changes = [write_capacity, read_capacity] }
 }
 
 module "reach_table_autoscaling" {


### PR DESCRIPTION
Github Issue: #105 Only benchmarking data is l oaded even when load_benchmarking_data flag is false

### Description

After ability to add benchmarking data was added no new data granules could be loaded in the database. The load_benchmarking_data flag when invoking the lambda function was not being respected. 

### Overview of work done

Change the flag check from expecting a boolean to expect a string

### Overview of verification done

No new unit tests, existing ones continue to pass.

### Overview of integration done

Deployed change to SIT and confirmed that new granules can be loaded successfully into the database.

## PR checklist:

* [x] Linted
* [x] Updated unit tests
* [x] Updated changelog
* [x] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_