### PR TITLE
Update examples.md

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -4,7 +4,7 @@
 
 Search for a single river reach by reach ID.
 
-    /timeseries?feature=Reach&feature_id=73111000545&output=geojson&start_time=2023-06-04T00:00:00&end_time=2023-06-10T00:00:00&fields=feature_id,time_str,wse,geometry
+    /timeseries?feature=Reach&feature_id=73111000545&output=geojson&start_time=2023-06-04T00:00:00Z&end_time=2023-06-10T00:00:00Z&fields=feature_id,time_str,wse,geometry
 
 Will return geojson, eg:
 


### PR DESCRIPTION
Updated example re issue #129. Let me know if adding the Z will throw anything off.

Github Issue: #129 

### Description

Update example with datetime format including 'Z' at the end of both dates since a user indicated it gave this error if the Z wasn't there:
"error" : "400: start_time and end_time parameters must conform to format: YYYY-MM-DDTHH:MM:SS+00:00"

### Overview of work done

Added 'Z' into example in both places.

### Overview of verification done

I tried this link without the Z's and it threw the same error the user got:

https://soto.podaac.uat.earthdatacloud.nasa.gov/hydrocron/v1/timeseries?feature=Reach&feature_id=72390300011&start_time=2024-01-01T00:00:00Z&end_time=2024-10-30T00:00:00Z&output=geojson&fields=reach_id,time_str,wse,geometry

### Overview of integration done

N/A

## PR checklist:

* [ ] Linted
* [ ] Updated unit tests
* [ ] Updated changelog
* [ ] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_