### PR TITLE
Feature/issue 131: Error message when incorrect time format entered suggests a time format that also fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
     - Issue 39 - Clean up code, removed comments and unused parameters
 ### Fixed
+    - Issue 131 - Error message when incorrect time format entered suggests a time format that also fails
     - Issue 105 - Only benchmarking data is being loaded even when load_benchmarking_data flag is false
     - Issue 44 - Load data lambda only loads the first granule found in the time range
     - Issue 116 - CICD will not publish when build run as workflow dispatch

--- a/hydrocron/api/controllers/timeseries.py
+++ b/hydrocron/api/controllers/timeseries.py
@@ -185,7 +185,7 @@ def validate_parameters(feature, feature_id, start_time, end_time, output, field
 
     elif not is_date_valid(start_time) or not is_date_valid(end_time):
         data['http_code'] = '400 Bad Request'
-        data['error_message'] = '400: start_time and end_time parameters must conform to format: YYYY-MM-DDTHH:MM:SS+00:00'
+        data['error_message'] = '400: start_time and end_time parameters must conform to format: YYYY-MM-DDTHH:MM:SSZ or YYYY-MM-DDTHH:MM:SS-00:00'
 
     elif output not in ('csv', 'geojson'):
         data['http_code'] = '400 Bad Request'

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -517,7 +517,7 @@ def test_timeseries_lambda_handler_dates(hydrocron_api):
     context = "_"
     with pytest.raises(hydrocron.api.controllers.timeseries.RequestError) as e:
         hydrocron.api.controllers.timeseries.lambda_handler(event, context)
-    assert "400: start_time and end_time parameters must conform to format: YYYY-MM-DDTHH:MM:SS+00:00" in str(e.value)
+    assert "400: start_time and end_time parameters must conform to format: YYYY-MM-DDTHH:MM:SSZ or YYYY-MM-DDTHH:MM:SS-00:00" in str(e.value)
 
 
 def test_timeseries_lambda_handler_output(hydrocron_api):


### PR DESCRIPTION
Github Issue: [#131](https://github.com/podaac/hydrocron/issues/131)

### Description

Error message when incorrect time format entered suggests a time format that also fails.

### Overview of work done

Modified the error message returned for invalid dates to display valid date formats.

### Overview of verification done

Updated unit test that tests for cases where the request date is invalid. Passes other existing unit tests.

### Overview of integration done

Deployed and tested to SIT.

Request (Dates are valid)

```bash
curl --location --request GET 'https://soto.podaac.sit.earthdatacloud.nasa.gov/hydrocron/v1/timeseries?feature=Reach&feature_id=63470800171&start_time=2024-02-01T00:00:00%2b00:00&end_time=2024-10-30T00:00:00%2b00:00&output=csv&fields=reach_id,time_str,wse'
```

Respnse

```json
{"status":"200 OK","time":2092.594,"hits":2,"results":{"csv":"reach_id,time_str,wse,wse_units\n63470800171,2024-02-01T02:26:50Z,2419.238,m\n63470800171,2024-02-08T13:48:41Z,1453.4136,m\n","geojson":{}}}
```

Request (Dates are invalid)

```bash
curl --location --request GET 'https://soto.podaac.sit.earthdatacloud.nasa.gov/hydrocron/v1/timeseries?feature=Reach&feature_id=63470800171&start_time=2024-02-01T00:00:00+00:00&end_time=2024-10-30T00:00:00+00:00&output=csv&fields=reach_id,time_str,wse'
```

Respnse

```json
{
  "error" : "400: start_time and end_time parameters must conform to format: YYYY-MM-DDTHH:MM:SSZ or YYYY-MM-DDTHH:MM:SS-00:00"
}
```

## PR checklist:

* [X] Linted
* [X] Updated unit tests
* [X] Updated changelog
* [X] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_