### PR TITLE
Feature/issue 126: Capture and log client IP address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+    - Issue 126 - Capture and log the client IP address
     - Issue 89 - Pass headers to timeseries Lambda and test for 'Elastic-Heartbeat' in 'User-Agent' header
     - Issue 24 - Indicate which collection version the data belongs to
     - Issue 13 - Add SWORD version from shp.xml to DB entries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+    - Issue 89 - Pass headers to timeseries Lambda and test for 'Elastic-Heartbeat' in 'User-Agent' header
     - Issue 24 - Indicate which collection version the data belongs to
     - Issue 13 - Add SWORD version from shp.xml to DB entries
     - Issue 85 - Add variable units to API response

--- a/hydrocron/api/controllers/timeseries.py
+++ b/hydrocron/api/controllers/timeseries.py
@@ -265,6 +265,7 @@ def lambda_handler(event, context):  # noqa: E501 # pylint: disable=W0613
     try:
         if event['body'] == {} and 'Elastic-Heartbeat' in event['headers']['User-Agent']:
             return {}
+        print(f'user_ip: {event["headers"]["X-Forwarded-For"].split(",")[0]}')
     except KeyError as e:
         print(f'Error encountered with headers: {e}')
         raise RequestError('400: Issue encountered with request headers') from e

--- a/hydrocron/api/controllers/timeseries.py
+++ b/hydrocron/api/controllers/timeseries.py
@@ -260,10 +260,15 @@ def lambda_handler(event, context):  # noqa: E501 # pylint: disable=W0613
     start = time.time()
     print(f'Event - {event}')
 
-    if event['body'] == {} and 'Elastic-Heartbeat' in event['headers']['User-Agent']:
-        return {}
-
     results = {'http_code': '200 OK'}
+
+    try:
+        if event['body'] == {} and 'Elastic-Heartbeat' in event['headers']['User-Agent']:
+            return {}
+    except KeyError as e:
+        print(f'Error encountered with headers: {e}')
+        raise RequestError('400: Issue encountered with request headers') from e
+
     try:
         feature = event['body']['feature']
         feature_id = event['body']['feature_id']

--- a/hydrocron/api/controllers/timeseries.py
+++ b/hydrocron/api/controllers/timeseries.py
@@ -258,9 +258,9 @@ def lambda_handler(event, context):  # noqa: E501 # pylint: disable=W0613
     """
 
     start = time.time()
-    print(f"Event - {event}")
+    print(f'Event - {event}')
 
-    if "Elastic-Heartbeat" in event["headers"]["User-Agent"]:
+    if event['body'] == {} and 'Elastic-Heartbeat' in event['headers']['User-Agent']:
         return {}
 
     results = {'http_code': '200 OK'}

--- a/hydrocron/api/controllers/timeseries.py
+++ b/hydrocron/api/controllers/timeseries.py
@@ -259,7 +259,7 @@ def lambda_handler(event, context):  # noqa: E501 # pylint: disable=W0613
 
     start = time.time()
     print(f"Event - {event}")
-    
+
     if "Elastic-Heartbeat" in event["headers"]["User-Agent"]:
         return {}
 

--- a/hydrocron/api/controllers/timeseries.py
+++ b/hydrocron/api/controllers/timeseries.py
@@ -259,6 +259,9 @@ def lambda_handler(event, context):  # noqa: E501 # pylint: disable=W0613
 
     start = time.time()
     print(f"Event - {event}")
+    
+    if "Elastic-Heartbeat" in event["headers"]["User-Agent"]:
+        return {}
 
     results = {'http_code': '200 OK'}
     try:

--- a/terraform/api-specification-templates/hydrocron_aws_api.yml
+++ b/terraform/api-specification-templates/hydrocron_aws_api.yml
@@ -152,14 +152,23 @@ paths:
         requestTemplates:
           application/json: |-
             #set($queryParams = $input.params().querystring)
+            #set($headerParams = $input.params().header)
             {
-            "body" :
-            {
-              #foreach($paramName in $queryParams.keySet())
-              "$paramName": "$util.escapeJavaScript($queryParams.get($paramName))"
-                #if($foreach.hasNext),#end
-              #end
-            }}
+              "body" :
+              {
+                #foreach($paramName in $queryParams.keySet())
+                "$paramName": "$util.escapeJavaScript($queryParams.get($paramName))"
+                  #if($foreach.hasNext),#end
+                #end
+              },
+              "headers" : 
+              {
+                #foreach($header in $headerParams.keySet())
+                "$header": "$util.escapeJavaScript($input.params().header.get($header))" 
+                  #if($foreach.hasNext),#end
+                #end
+              }
+            }
         passthroughBehavior: when_no_templates
         httpMethod: POST
         contentHandling: CONVERT_TO_TEXT

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -622,3 +622,22 @@ def test_timeseries_lambda_handler_elastic_agent(hydrocron_api):
     context = "_"
     result = hydrocron.api.controllers.timeseries.lambda_handler(event, context)
     assert result == {}
+    
+def test_timeseries_lambda_handler_missing_header(hydrocron_api):
+    """
+    Test the lambda handler for cases where invoked by Elastic Agent.
+    Parameters
+    ----------
+    hydrocron_api: Fixture ensuring the database is configured for the api
+    """
+    import hydrocron.api.controllers.timeseries
+
+    event = {
+        "body": {},
+        "headers": {}
+    }
+
+    context = "_"
+    with pytest.raises(hydrocron.api.controllers.timeseries.RequestError) as e:
+        hydrocron.api.controllers.timeseries.lambda_handler(event, context)
+        assert "400: Issue encountered with request headers" in str(e.value)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -29,7 +29,8 @@ def test_timeseries_lambda_handler_geojson(hydrocron_api):
             "fields": "reach_id,time_str,wse,sword_version,collection_shortname,crid"
         },
         "headers": {
-            "User-Agent": "curl/8.4.0"
+            "User-Agent": "curl/8.4.0",
+            "X-Forwarded-For": "123.456.789.000"
         }
     }
 
@@ -248,7 +249,8 @@ def test_timeseries_lambda_handler_validate_geojson_reach(hydrocron_api):
             "fields": "reach_id,time_str,wse,slope,time"
         },
         "headers": {
-            "User-Agent": "curl/8.4.0"
+            "User-Agent": "curl/8.4.0",
+            "X-Forwarded-For": "123.456.789.000"
         }
     }
 
@@ -277,7 +279,8 @@ def test_timeseries_lambda_handler_csv(hydrocron_api):
             "fields": "reach_id,time_str,wse,sword_version,collection_shortname,crid,geometry"
         },
         "headers": {
-            "User-Agent": "curl/8.4.0"
+            "User-Agent": "curl/8.4.0",
+            "X-Forwarded-For": "123.456.789.000"
         }
     }
 
@@ -432,7 +435,8 @@ def test_timeseries_lambda_handler_missing(hydrocron_api):
     event = {
         "body": {},
         "headers": {
-            "User-Agent": "curl/8.4.0"
+            "User-Agent": "curl/8.4.0",
+            "X-Forwarded-For": "123.456.789.000"
         }
     }
     context = "_"
@@ -449,7 +453,8 @@ def test_timeseries_lambda_handler_missing(hydrocron_api):
             "fields": "reach_id,time_str,wse,geometry"
         },
         "headers": {
-            "User-Agent": "curl/8.4.0"
+            "User-Agent": "curl/8.4.0",
+            "X-Forwarded-For": "123.456.789.000"
         }
     }
     context = "_"
@@ -477,7 +482,8 @@ def test_timeseries_lambda_handler_feature(hydrocron_api):
             "fields": "reach_id,time_str,wse,geometry"
         },
         "headers": {
-            "User-Agent": "curl/8.4.0"
+            "User-Agent": "curl/8.4.0",
+            "X-Forwarded-For": "123.456.789.000"
         }
     }
 
@@ -506,7 +512,8 @@ def test_timeseries_lambda_handler_feature_id(hydrocron_api):
             "fields": "reach_id,time_str,wse,geometry"
         },
         "headers": {
-            "User-Agent": "curl/8.4.0"
+            "User-Agent": "curl/8.4.0",
+            "X-Forwarded-For": "123.456.789.000"
         }
     }
 
@@ -536,7 +543,8 @@ def test_timeseries_lambda_handler_dates(hydrocron_api):
             "fields": "reach_id,time_str,wse,geometry"
         },
         "headers": {
-            "User-Agent": "curl/8.4.0"
+            "User-Agent": "curl/8.4.0",
+            "X-Forwarded-For": "123.456.789.000"
         }
     }
 
@@ -565,7 +573,8 @@ def test_timeseries_lambda_handler_output(hydrocron_api):
             "fields": "reach_id,time_str,wse,geometry"
         },
         "headers": {
-            "User-Agent": "curl/8.4.0"
+            "User-Agent": "curl/8.4.0",
+            "X-Forwarded-For": "123.456.789.000"
         }
     }
 
@@ -594,7 +603,8 @@ def test_timeseries_lambda_handler_fields(hydrocron_api):
             "fields": "reach_id,time_str,wse,geometry,height"
         },
         "headers": {
-            "User-Agent": "curl/8.4.0"
+            "User-Agent": "curl/8.4.0",
+            "X-Forwarded-For": "123.456.789.000"
         }
     }
 
@@ -615,7 +625,8 @@ def test_timeseries_lambda_handler_elastic_agent(hydrocron_api):
     event = {
         "body": {},
         "headers": {
-            "User-Agent": "Elastic-Heartbeat/7.16.2 (linux; amd64; 3c518f4d17a15dc85bdd68a5a03d5af51d9edd8e; 2021-12-18 21:10:52 +0000 UTC)"
+            "User-Agent": "Elastic-Heartbeat/7.16.2 (linux; amd64; 3c518f4d17a15dc85bdd68a5a03d5af51d9edd8e; 2021-12-18 21:10:52 +0000 UTC)",
+            "X-Forwarded-For": "123.456.789.000"
         }
     }
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -27,6 +27,9 @@ def test_timeseries_lambda_handler_geojson(hydrocron_api):
             "end_time": "2023-06-23T00:00:00Z",
             "output": "geojson",
             "fields": "reach_id,time_str,wse,sword_version,collection_shortname,crid"
+        },
+        "headers": {
+            "User-Agent": "curl/8.4.0"
         }
     }
 
@@ -243,6 +246,9 @@ def test_timeseries_lambda_handler_validate_geojson_reach(hydrocron_api):
             "end_time": "2023-06-23T00:00:00Z",
             "output": "geojson",
             "fields": "reach_id,time_str,wse,slope,time"
+        },
+        "headers": {
+            "User-Agent": "curl/8.4.0"
         }
     }
 
@@ -269,6 +275,9 @@ def test_timeseries_lambda_handler_csv(hydrocron_api):
             "end_time": "2023-06-23T00:00:00Z",
             "output": "csv",
             "fields": "reach_id,time_str,wse,sword_version,collection_shortname,crid,geometry"
+        },
+        "headers": {
+            "User-Agent": "curl/8.4.0"
         }
     }
 
@@ -420,7 +429,12 @@ def test_timeseries_lambda_handler_missing(hydrocron_api):
     """
     import hydrocron.api.controllers.timeseries
 
-    event = {"body": {}}
+    event = {
+        "body": {},
+        "headers": {
+            "User-Agent": "curl/8.4.0"
+        }
+    }
     context = "_"
     with pytest.raises(hydrocron.api.controllers.timeseries.RequestError) as e:
         hydrocron.api.controllers.timeseries.lambda_handler(event, context)
@@ -433,6 +447,9 @@ def test_timeseries_lambda_handler_missing(hydrocron_api):
             "end_time": "2023-06-23T00:00:00Z",
             "output": "geojson",
             "fields": "reach_id,time_str,wse,geometry"
+        },
+        "headers": {
+            "User-Agent": "curl/8.4.0"
         }
     }
     context = "_"
@@ -458,6 +475,9 @@ def test_timeseries_lambda_handler_feature(hydrocron_api):
             "end_time": "2023-06-23T00:00:00Z",
             "output": "geojson",
             "fields": "reach_id,time_str,wse,geometry"
+        },
+        "headers": {
+            "User-Agent": "curl/8.4.0"
         }
     }
 
@@ -484,6 +504,9 @@ def test_timeseries_lambda_handler_feature_id(hydrocron_api):
             "end_time": "2023-06-23T00:00:00Z",
             "output": "geojson",
             "fields": "reach_id,time_str,wse,geometry"
+        },
+        "headers": {
+            "User-Agent": "curl/8.4.0"
         }
     }
 
@@ -511,6 +534,9 @@ def test_timeseries_lambda_handler_dates(hydrocron_api):
             "end_time": "2023-06-23T00:00:00Z",
             "output": "geojson",
             "fields": "reach_id,time_str,wse,geometry"
+        },
+        "headers": {
+            "User-Agent": "curl/8.4.0"
         }
     }
 
@@ -537,6 +563,9 @@ def test_timeseries_lambda_handler_output(hydrocron_api):
             "end_time": "2023-06-23T00:00:00Z",
             "output": "txt",
             "fields": "reach_id,time_str,wse,geometry"
+        },
+        "headers": {
+            "User-Agent": "curl/8.4.0"
         }
     }
 
@@ -563,6 +592,9 @@ def test_timeseries_lambda_handler_fields(hydrocron_api):
             "end_time": "2023-06-23T00:00:00Z",
             "output": "geojson",
             "fields": "reach_id,time_str,wse,geometry,height"
+        },
+        "headers": {
+            "User-Agent": "curl/8.4.0"
         }
     }
 
@@ -570,3 +602,23 @@ def test_timeseries_lambda_handler_fields(hydrocron_api):
     with pytest.raises(hydrocron.api.controllers.timeseries.RequestError) as e:
         hydrocron.api.controllers.timeseries.lambda_handler(event, context)
         assert "400: fields parameter should contain valid SWOT fields" in str(e.value)
+
+def test_timeseries_lambda_handler_elastic_agent(hydrocron_api):
+    """
+    Test the lambda handler for cases where invoked by Elastic Agent.
+    Parameters
+    ----------
+    hydrocron_api: Fixture ensuring the database is configured for the api
+    """
+    import hydrocron.api.controllers.timeseries
+
+    event = {
+        "body": {},
+        "headers": {
+            "User-Agent": "Elastic-Heartbeat/7.16.2 (linux; amd64; 3c518f4d17a15dc85bdd68a5a03d5af51d9edd8e; 2021-12-18 21:10:52 +0000 UTC)"
+        }
+    }
+
+    context = "_"
+    result = hydrocron.api.controllers.timeseries.lambda_handler(event, context)
+    assert result == {}


### PR DESCRIPTION
Github Issue: [#126](https://github.com/podaac/hydrocron/issues/126)

### Description

Capture and log client IP address in Hydrocron execution, access, or time series Lambda logs.

### Overview of work done

- Modify the timeseries module so that it logs the client IP address by accessing the `X-Forwarded-For` header.

### Overview of verification done

- Update API unit tests to include the `X-Forwarded-For` header, all unit tests pass.

### Overview of integration done

Code was deployed to the SIT environment. The logs now display the client's IP.

```bash
2024-04-01T15:58:49.370-04:00 START RequestId: xxxxxxxxxxxxxxxxx Version: $LATEST
2024-04-01T15:58:49.370-04:00 [INFO] 2024-04-01T19:58:49.370Z xxxxxxxxxxxxxxxxx headers: {"Accept": "*/*", "Accept-Encoding": "identity", "Host": "xxxx.execute-api.us-west-2.amazonaws.com", "User-Agent": "curl/8.4.0", "Via": "2.0 xxxxx.cloudfront.net (CloudFront)", "x-additional-custom-origin": "true", "x-amzn-cipher-suite": "xxxxx", "x-amzn-tls-version": "TLSv1.2", "X-Amzn-Trace-Id": "Root=1-xxxxxxxx", "x-amzn-vpc-id": "vpc-xxxxxx", "x-amzn-vpce-config": "1", "x-amzn-vpce-id": "vpce-xxxxxx", "x-api-key": "xxxxx", "X-Forwarded-For": "123.456.789.000", "X-Forwarded-Host": "xxxxx.execute-api.us-west-2.amazonaws.com", "X-Forwarded-Port": "443", "X-Forwarded-Proto": "https"}
2024-04-01T15:58:49.370-04:00 [INFO] 2024-04-01T19:58:49.370Z xxxxxxxxxxxxxxxxx request: {"end_time": "2024-10-30T00:00:00+00:00", "feature": "Reach", "feature_id": "63470800171", "fields": "reach_id,time_str,wse", "output": "csv", "start_time": "2024-02-01T00:00:00+00:00"}
2024-04-01T15:58:49.370-04:00 [INFO] 2024-04-01T19:58:49.370Z xxxxxxxxxxxxxxxxx user_ip: 123.456.789.000
2024-04-01T15:58:49.760-04:00 [INFO] 2024-04-01T19:58:49.760Z xxxxxxxxxxxxxxxxx Found credentials in environment variables.
2024-04-01T15:58:51.180-04:00 [INFO] 2024-04-01T19:58:51.180Z xxxxxxxxxxxxxxxxx query_size: 232
2024-04-01T15:58:51.699-04:00 [INFO] 2024-04-01T19:58:51.699Z xxxxxxxxxxxxxxxxx response: {"status": "200 OK", "time": 2328.99, "hits": 2, "results": {"csv": "reach_id,time_str,wse,wse_units\n63470800171,2024-02-01T02:26:50Z,2419.238,m\n63470800171,2024-02-08T13:48:41Z,1453.4136,m\n", "geojson": {}}}
2024-04-01T15:58:51.699-04:00 [INFO] 2024-04-01T19:58:51.699Z xxxxxxxxxxxxxxxxx response_size: 232
2024-04-01T15:58:51.701-04:00 END RequestId: xxxxxxxxxxxxxxxxx 
```

## PR checklist:

* [X] Linted
* [X] Updated unit tests
* [X] Updated changelog
* [X] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_