### PR TITLE
Feature/issue 144 - The timeseries Lambda function logs the user_ip twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated 
 ### Removed
 ### Fixed
-    - Issue 144 - The timeseries Lambda function logs the user_ip twice
 ### Security
 
 ## [1.1.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated 
 ### Removed
 ### Fixed
+    - Issue 144 - The timeseries Lambda function logs the user_ip twice
 ### Security
 
 ## [1.1.0]

--- a/hydrocron/api/controllers/timeseries.py
+++ b/hydrocron/api/controllers/timeseries.py
@@ -274,15 +274,6 @@ def lambda_handler(event, context):  # noqa: E501 # pylint: disable=W0613
         raise RequestError(f'400: Issue encountered with request header: {e}') from e
 
     results = {'http_code': '200 OK'}
-
-    try:
-        if event['body'] == {} and 'Elastic-Heartbeat' in event['headers']['User-Agent']:
-            return {}
-        print(f'user_ip: {event["headers"]["X-Forwarded-For"].split(",")[0]}')
-    except KeyError as e:
-        print(f'Error encountered with headers: {e}')
-        raise RequestError('400: Issue encountered with request headers') from e
-
     try:
         feature = event['body']['feature']
         feature_id = event['body']['feature_id']


### PR DESCRIPTION
Github Issue: #144

### Description

The timeseries Lambda function logs the user_ip twice.

### Overview of work done

Removed the duplicated print statements from the timeseries module.

### Overview of verification done

Very minor modification so no new unit tests created, existing unit tests pass.

### Overview of integration done

Deployed to SIT environment and confirmed logging of `user_ip` only occurs once and is expected.

```bash
2024-04-04T15:29:38.643-04:00 [INFO] 2024-04-04T19:29:38.643Z a700f531-7ac8-461c-bc61-50b8d8a70a3f headers: {...}
2024-04-04T15:29:38.643-04:00 [INFO] 2024-04-04T19:29:38.643Z a700f531-7ac8-461c-bc61-50b8d8a70a3f request: {"end_time": "2024-10-30T00:00:00+00:00", "feature": "Reach", "feature_id": "63470800171", "fields": "reach_id,time_str,wse", "output": "csv", "start_time": "2024-02-01T00:00:00+00:00"}
2024-04-04T15:29:38.643-04:00 [INFO] 2024-04-04T19:29:38.643Z a700f531-7ac8-461c-bc61-50b8d8a70a3f user_ip: 128.149.241.129
2024-04-04T15:29:38.949-04:00 [INFO] 2024-04-04T19:29:38.949Z a700f531-7ac8-461c-bc61-50b8d8a70a3f query_size: 232
2024-04-04T15:29:39.108-04:00 [INFO] 2024-04-04T19:29:39.108Z a700f531-7ac8-461c-bc61-50b8d8a70a3f response: {"status": "200 OK", "time": 465.397, "hits": 2, "results": {"csv": "reach_id,time_str,wse,wse_units\n63470800171,2024-02-01T02:26:50Z,3386.9332,m\n63470800171,2024-02-08T13:48:41Z,1453.4136,m\n", "geojson": {}}}
2024-04-04T15:29:39.108-04:00 [INFO] 2024-04-04T19:29:39.108Z a700f531-7ac8-461c-bc61-50b8d8a70a3f response_size: 232 
```

## PR checklist:

* [X] Linted
* [X] Updated unit tests
* [X] Updated changelog
* [X] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_