### PR TITLE
Feature/issue 169

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated 
 ### Removed
 ### Fixed
+    - Issue 169 - 403 Error when accessing grnule through bulk load_data
     - Issue 158 - Use Lambda role instead of EDL for s3 connection
     - Issue 104 - Prevent nodes from being loaded into the reach table
 ### Security

--- a/terraform/hydrocron-lambda.tf
+++ b/terraform/hydrocron-lambda.tf
@@ -99,6 +99,8 @@ resource "aws_lambda_function" "hydrocron_lambda_load_data" {
   tags = var.default_tags
   environment {
     variables = {
+      EARTHDATA_USERNAME = data.aws_ssm_parameter.edl_username.value
+      EARTHDATA_PASSWORD = data.aws_ssm_parameter.edl_password.value
       GRANULE_LAMBDA_FUNCTION_NAME = aws_lambda_function.hydrocron_lambda_load_granule.function_name
     }
   }
@@ -122,8 +124,6 @@ resource "aws_lambda_function" "hydrocron_lambda_load_granule" {
   tags = var.default_tags
   environment {
     variables = {
-      EARTHDATA_USERNAME = data.aws_ssm_parameter.edl_username.value
-      EARTHDATA_PASSWORD = data.aws_ssm_parameter.edl_password.value
       OBSCURE_DATA = "false"
     }
   }

--- a/terraform/hydrocron-lambda.tf
+++ b/terraform/hydrocron-lambda.tf
@@ -122,6 +122,8 @@ resource "aws_lambda_function" "hydrocron_lambda_load_granule" {
   tags = var.default_tags
   environment {
     variables = {
+      EARTHDATA_USERNAME = data.aws_ssm_parameter.edl_username.value
+      EARTHDATA_PASSWORD = data.aws_ssm_parameter.edl_password.value
       OBSCURE_DATA = "false"
     }
   }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -46,6 +46,14 @@ data "aws_subnets" "private_application_subnets" {
   }
 }
 
+data "aws_ssm_parameter" "edl_username" {
+  name = "urs_podaaccloud_user"
+}
+data "aws_ssm_parameter" "edl_password" {
+  name = "urs_podaaccloud_pass"
+  with_decryption = true
+}
+
 locals {
   environment = var.stage
   account_id  = data.aws_caller_identity.current.account_id


### PR DESCRIPTION
Github Issue: #169 

### Description

Removing the EDL credentials caused authentication errors when there is a mix of venues (ie loading OPS data in SIT).

### Overview of work done

Restored the EDL environment vars so the CMR query in the load_data lambda succeeds. Also worked with Stepheny to allow lambda role access on the SWOT OPS bucket from SIT and UAT.

### Overview of verification done

Unit tests pass

### Overview of integration done

Deployed to SIT and verified all the lambdas load data successfully

## PR checklist:

* [x] Linted
* [ ] Updated unit tests
* [x] Updated changelog
* [x] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_