### PR TITLE
Hack to force lambda deployment when ssm value changes

### DIFF
--- a/terraform/hydrocron-apigw.tf
+++ b/terraform/hydrocron-apigw.tf
@@ -126,7 +126,7 @@ resource "aws_ssm_parameter" "trusted-user-parameter" {
   type        = "SecureString"
   value = jsonencode(
     [
-      "${aws_api_gateway_api_key.confluence-user-key.value}"
+      aws_api_gateway_api_key.confluence-user-key.value
     ]
   )
 }

--- a/terraform/hydrocron-lambda.tf
+++ b/terraform/hydrocron-lambda.tf
@@ -88,9 +88,8 @@ resource "null_resource" "api_key_hash" {
   This resource is needed because of https://github.com/podaac/hydrocron/issues/205#issuecomment-2250982988
    */
   triggers = {
-    value = sha256(join(",", [
-      aws_ssm_parameter.default-user-parameter.value, aws_ssm_parameter.trusted-user-parameter.value
-    ]))
+    default_key = aws_ssm_parameter.default-user-parameter.value
+    trusted_key_list = aws_ssm_parameter.trusted-user-parameter.value
   }
 }
 

--- a/terraform/hydrocron-lambda.tf
+++ b/terraform/hydrocron-lambda.tf
@@ -97,6 +97,9 @@ resource "aws_lambda_function" "hydrocron_lambda_authorizer" {
     subnet_ids         = data.aws_subnets.private_application_subnets.ids
     security_group_ids = data.aws_security_groups.vpc_default_sg.ids
   }
+  lifecycle {
+    replace_triggered_by = [aws_ssm_parameter.trusted-user-parameter.value, aws_ssm_parameter.default-user-parameter.value]
+  }
   tags = var.default_tags
 }
 


### PR DESCRIPTION
* Add a null resource that is triggered by the API keys' SSM values. Whenever an api key is added/deleted/changed the null resource will be recreated
* Create an environment variable on the lambda which is simply the `id` of the null_resource, so when the null resource gets recreated, the environment of the lambda changes
* Set the `publish` attribute on the lambda to `true`, so when the environment changes a new version of the lambda is published
* Publishing a new version of the lambda forces the "cold-start" for future executions of that function
* The cold-start will cause the lambda initialization to run and lookup the (new) values for the API keys from SSM