### PR TITLE
Feature/issue-225: Create one track ingest table per feature type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+    - Issue 225 - Create one track ingest table per feature type
     - Issue 222 - Add operations to load granule Lambda to write granule record to track ingest database
     - Issue 201 - Create table for tracking granule ingest status
     - Issue 198 - Implement track ingest lambda function CMR and Hydrocron queries

--- a/hydrocron/utils/constants.py
+++ b/hydrocron/utils/constants.py
@@ -128,7 +128,9 @@ TEST_PLAKE_UNITS = 'km^2'
 SWOT_REACH_TABLE_NAME = "hydrocron-swot-reach-table"
 SWOT_NODE_TABLE_NAME = "hydrocron-swot-node-table"
 SWOT_PRIOR_LAKE_TABLE_NAME = "hydrocron-swot-prior-lake-table"
-TRACK_INGEST_TABLE_NAME = "hydrocron-track-ingest-table"
+SWOT_REACH_TRACK_INGEST_TABLE_NAME = "hydrocron-swot-reach-track-ingest-table"
+SWOT_NODE_TRACK_INGEST_TABLE_NAME = "hydrocron-swot-node-track-ingest-table"
+SWOT_PRIOR_LAKE_TRACK_INGEST_TABLE_NAME = "hydrocron-swot-prior-lake-track-ingest-table"
 
 SWOT_REACH_COLLECTION_NAME = "SWOT_L2_HR_RiverSP_2.0"
 SWOT_NODE_COLLECTION_NAME = "SWOT_L2_HR_RiverSP_2.0"

--- a/terraform/hydrocron-dynamo.tf
+++ b/terraform/hydrocron-dynamo.tf
@@ -87,8 +87,62 @@ resource "aws_dynamodb_table" "hydrocron-swot-prior-lake-table" {
   }
 }
 
-resource "aws_dynamodb_table" "hydrocron-track-ingest-table" {
-  name         = "hydrocron-track-ingest-table"
+resource "aws_dynamodb_table" "hydrocron-reach-track-ingest-table" {
+  name         = "hydrocron-swot-reach-track-ingest-table"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "granuleUR"
+  range_key    = "revision_date"
+  attribute {
+    name = "granuleUR"
+    type = "S"
+  }
+  attribute {
+    name = "revision_date"
+    type = "S"
+  }
+  attribute {
+    name = "status"
+    type = "S"
+  }
+  global_secondary_index {
+    name               = "statusIndex"
+    hash_key           = "status"
+    projection_type    = "ALL"
+  }
+  point_in_time_recovery {
+    enabled = var.stage == "ops" ? true : false
+  }
+}
+
+resource "aws_dynamodb_table" "hydrocron-node-track-ingest-table" {
+  name         = "hydrocron-swot-node-track-ingest-table"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "granuleUR"
+  range_key    = "revision_date"
+  attribute {
+    name = "granuleUR"
+    type = "S"
+  }
+  attribute {
+    name = "revision_date"
+    type = "S"
+  }
+  attribute {
+    name = "status"
+    type = "S"
+  }
+  global_secondary_index {
+    name               = "statusIndex"
+    hash_key           = "status"
+    projection_type    = "ALL"
+  }
+  point_in_time_recovery {
+    enabled = var.stage == "ops" ? true : false
+  }
+}
+
+resource "aws_dynamodb_table" "hydrocron-priorlake-track-ingest-table" {
+  name         = "hydrocron-swot-prior-lake-track-ingest-table"
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "granuleUR"
   range_key    = "revision_date"

--- a/terraform/hydrocron-iam.tf
+++ b/terraform/hydrocron-iam.tf
@@ -67,7 +67,9 @@ data "aws_iam_policy_document" "dynamo-read-policy-track-ingest" {
     ]
 
     resources = [
-      aws_dynamodb_table.hydrocron-track-ingest-table.arn,
+      aws_dynamodb_table.hydrocron-reach-track-ingest-table.arn,
+      aws_dynamodb_table.hydrocron-node-track-ingest-table.arn,
+      aws_dynamodb_table.hydrocron-priorlake-track-ingest-table.arn,
     ]
   }
 
@@ -119,7 +121,9 @@ data "aws_iam_policy_document" "dynamo-write-policy-track-ingest" {
     ]
 
     resources = [
-      aws_dynamodb_table.hydrocron-track-ingest-table.arn
+      aws_dynamodb_table.hydrocron-reach-track-ingest-table.arn,
+      aws_dynamodb_table.hydrocron-node-track-ingest-table.arn,
+      aws_dynamodb_table.hydrocron-priorlake-track-ingest-table.arn,
     ]
   }
 


### PR DESCRIPTION

Github Issue: #225 Create one track ingest table per feature type

### Description

To make the track ingest module cleaner and to support easier queries, separate track ingest status for reaches, nodes and prior lakes into separate dynamodb tables.

### Overview of work done

* add constants for track ingest tables for reach, node, prior lake
* adjust load_data module to pass identify track table name and pass to load granule lambda
* add new track ingest tables to dynamodb terraform and set permissions in IAM terraform

### Overview of verification done

No changes to unit tests, existing tests pass

### Overview of integration done

Deployed to SIT and verified that load granule invoked by CNM lambda correctly identifies the feature specific tracking table and loads the granule info:

<img width="1452" alt="image" src="https://github.com/user-attachments/assets/268d0786-f40d-4357-9292-2c4a92adca65">


## PR checklist:

* [x] Linted
* [x] Updated unit tests
* [x] Updated changelog
* [x] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_