### PR TITLE
Feature/Issue-251 - Add note to readme to point to documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Issue 203 - Construct CNM to trigger load data operations and ingest granule
     - Issue 236 - Allow UAT query of CMR to support querying in different venues
 ### Changed
+    - Issue 251 - Add note to readme to point to documentation
 ### Deprecated
 ### Removed
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 ## Overview
 
-Hydrocron API is a new tool that implements functionalities that will allow 
-hydrologists to have direct access to filtered data from our newest satellites. 
-This innovative tool will provide an effortless way to filter data by feature ID, 
-date range, polygonal area, and more. This data will be returned in formats such 
-as CSV and geoJSON.
+Hydrocron is an API that repackages hydrology datasets from the Surface Water and Ocean Topography (SWOT) satellite into formats that make time-series analysis easier, including GeoJSON and CSV. To use Hydrocron, see the official documentation with examples and tutorials here: [https://podaac.github.io/hydrocron/intro.html](https://podaac.github.io/hydrocron/intro.html)
+
+The following sections of this readme describe how to install and run a development version of Hydrocron locally on your own computer. This is not recommended if you just want to access SWOT data through Hydrocron. To access data, see the documentation linked above.
+
+To contribute to the development of Hydrocron, see the [contributing guidelines](https://github.com/podaac/hydrocron/blob/develop/CONTRIBUTING.md) and browse the open issues.
+
+***NOTE: the following instructions for installing and running a local version of Hydrocron are out of date, and may result in a broken install. We are aware of the issue and working on restoring local development functionality. Please open a new issue or ask a question on the [PO.DAAC forum](https://podaac.jpl.nasa.gov/forum/viewforum.php?f=6) if you need to run a local installation.***
 
 ## Requirements
 


### PR DESCRIPTION
Github Issue: #251 Add note to readme to point to documentation

### Description

The readme is out of date and confusing for new users by making them think they need to install a local version of hydrocron.

### Overview of work done

Add note to readme to point to documentation for usage, and warning about readme instructions being broken. Fixing the local install and updating the readme to be accurate will be a bigger task done in #252 

### Overview of verification done

Documentation changes only. Previewed new readme.

### Overview of integration done

None, documentation changes only. 

## PR checklist:

* [x] Linted
* [ ] Updated unit tests
* [x] Updated changelog
* [ ] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_