### PR TITLE
267 - Modify track ingest operations to support new collection versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
     - Issue 229 - Create new database tables for version d collections
     - Issue 233 - Create new API parameter for user to specify data version
+    - Issue 267 - Modify track ingest operations to support new collection versions
 ### Changed
 ### Deprecated
 ### Removed

--- a/hydrocron/db/track_ingest.py
+++ b/hydrocron/db/track_ingest.py
@@ -517,8 +517,6 @@ def track_ingest_handler(event, context):
 
     account_id = context.invoked_function_arn.split(":")[4]
     collection_shortname = event["collection_shortname"]
-    hydrocron_table = event["hydrocron_table"]
-    hydrocron_track_table = event["hydrocron_track_table"]
     reprocessed_crid = event["reprocessed_crid"]
     temporal = "temporal" in event.keys()
 
@@ -554,7 +552,6 @@ def track_ingest_handler(event, context):
     cmr_granules = track.query_cmr(temporal)
     track.query_hydrocron(hydrocron_table, cmr_granules, reprocessed_crid)
     track.query_track_ingest(hydrocron_track_table, hydrocron_table, reprocessed_crid)
-    track.remove_overlap()
     track.publish_cnm_ingest(account_id)
     track.update_track_ingest(hydrocron_track_table)
     if not temporal:

--- a/hydrocron/db/track_ingest.py
+++ b/hydrocron/db/track_ingest.py
@@ -527,7 +527,7 @@ def track_ingest_handler(event, context):
             hydrocron_track_table = table_info['track_table']
             break
     else:
-        raise TableMisMatch(f"Error: Cannot query data for tables: '{hydrocron_table}' and '{hydrocron_track_table}'")
+        raise TableMisMatch(f"Error: Cannot query data for collection: '{collection_shortname}'")
 
     if temporal:
         query_start = datetime.datetime.strptime(event["query_start"], "%Y-%m-%dT%H:%M:%S").replace(tzinfo=timezone.utc)

--- a/terraform/hydrocron-dynamo.tf
+++ b/terraform/hydrocron-dynamo.tf
@@ -203,6 +203,33 @@ resource "aws_dynamodb_table" "hydrocron-reach-track-ingest-table" {
   }
 }
 
+resource "aws_dynamodb_table" "hydrocron-SWOT_L2_HR_RiverSP_D-reach-track-ingest-table" {
+  name         = "hydrocron-SWOT_L2_HR_RiverSP_D-reach-track-ingest"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "granuleUR"
+  range_key    = "revision_date"
+  attribute {
+    name = "granuleUR"
+    type = "S"
+  }
+  attribute {
+    name = "revision_date"
+    type = "S"
+  }
+  attribute {
+    name = "status"
+    type = "S"
+  }
+  global_secondary_index {
+    name            = "statusIndex"
+    hash_key        = "status"
+    projection_type = "ALL"
+  }
+  point_in_time_recovery {
+    enabled = var.stage == "ops" ? true : false
+  }
+}
+
 resource "aws_dynamodb_table" "hydrocron-node-track-ingest-table" {
   name         = "hydrocron-swot-node-track-ingest-table"
   billing_mode = "PAY_PER_REQUEST"
@@ -230,8 +257,62 @@ resource "aws_dynamodb_table" "hydrocron-node-track-ingest-table" {
   }
 }
 
+resource "aws_dynamodb_table" "hydrocron-SWOT_L2_HR_RiverSP_D-node-track-ingest-table" {
+  name         = "hydrocron-SWOT_L2_HR_RiverSP_D-node-track-ingest"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "granuleUR"
+  range_key    = "revision_date"
+  attribute {
+    name = "granuleUR"
+    type = "S"
+  }
+  attribute {
+    name = "revision_date"
+    type = "S"
+  }
+  attribute {
+    name = "status"
+    type = "S"
+  }
+  global_secondary_index {
+    name            = "statusIndex"
+    hash_key        = "status"
+    projection_type = "ALL"
+  }
+  point_in_time_recovery {
+    enabled = var.stage == "ops" ? true : false
+  }
+}
+
 resource "aws_dynamodb_table" "hydrocron-priorlake-track-ingest-table" {
   name         = "hydrocron-swot-prior-lake-track-ingest-table"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "granuleUR"
+  range_key    = "revision_date"
+  attribute {
+    name = "granuleUR"
+    type = "S"
+  }
+  attribute {
+    name = "revision_date"
+    type = "S"
+  }
+  attribute {
+    name = "status"
+    type = "S"
+  }
+  global_secondary_index {
+    name            = "statusIndex"
+    hash_key        = "status"
+    projection_type = "ALL"
+  }
+  point_in_time_recovery {
+    enabled = var.stage == "ops" ? true : false
+  }
+}
+
+resource "aws_dynamodb_table" "hydrocron-SWOT_L2_HR_LakeSP_D-prior-lake-track-ingest-table" {
+  name         = "hydrocron-SWOT_L2_HR_LakeSP_D-prior-lake-track-ingest"
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "granuleUR"
   range_key    = "revision_date"

--- a/terraform/hydrocron-eventbridge.tf
+++ b/terraform/hydrocron-eventbridge.tf
@@ -11,10 +11,8 @@ resource "aws_scheduler_schedule" "aws_schedule_reach" {
     role_arn = aws_iam_role.hydrocron_schedule_role.arn
     input = jsonencode({
       "collection_shortname" : "SWOT_L2_HR_RiverSP_reach_2.0",
-      "hydrocron_table" : "${aws_dynamodb_table.hydrocron-swot-reach-table.name}",
-      "hydrocron_track_table" : "${aws_dynamodb_table.hydrocron-reach-track-ingest-table.name}",
       "collection_start_date" : "2024-11-01T00:00:00",
-      "reprocessed_crid": "PGC0"
+      "reprocessed_crid" : "PGC0"
     })
   }
 }
@@ -33,10 +31,8 @@ resource "aws_scheduler_schedule" "aws_schedule_node" {
     role_arn = aws_iam_role.hydrocron_schedule_role.arn
     input = jsonencode({
       "collection_shortname" : "SWOT_L2_HR_RiverSP_node_2.0",
-      "hydrocron_table" : "${aws_dynamodb_table.hydrocron-swot-node-table.name}",
-      "hydrocron_track_table" : "${aws_dynamodb_table.hydrocron-node-track-ingest-table.name}",
       "collection_start_date" : "2024-11-01T00:00:00",
-      "reprocessed_crid": "PGC0"
+      "reprocessed_crid" : "PGC0"
     })
   }
 }
@@ -55,10 +51,8 @@ resource "aws_scheduler_schedule" "aws_schedule_prior_lake" {
     role_arn = aws_iam_role.hydrocron_schedule_role.arn
     input = jsonencode({
       "collection_shortname" : "SWOT_L2_HR_LakeSP_prior_2.0",
-      "hydrocron_table" : "${aws_dynamodb_table.hydrocron-swot-prior-lake-table.name}",
-      "hydrocron_track_table" : "${aws_dynamodb_table.hydrocron-priorlake-track-ingest-table.name}",
       "collection_start_date" : "2024-11-01T00:00:00",
-      "reprocessed_crid": "PGC0"
+      "reprocessed_crid" : "PGC0"
     })
   }
 }

--- a/terraform/hydrocron-lambda.tf
+++ b/terraform/hydrocron-lambda.tf
@@ -75,8 +75,8 @@ resource "aws_lambda_function" "hydrocron_lambda_timeseries" {
   environment {
     variables = {
       DEFAULT_COLLECTION_VERSION = "2.0"
-      DEFAULT_LAKE_COLLECTION = "SWOT_L2_HR_LakeSP"
-      DEFAULT_RIVER_COLLECTION = "SWOT_L2_HR_RiverSP"
+      DEFAULT_LAKE_COLLECTION    = "SWOT_L2_HR_LakeSP"
+      DEFAULT_RIVER_COLLECTION   = "SWOT_L2_HR_RiverSP"
     }
   }
   tags = var.default_tags

--- a/tests/test_track_ingest.py
+++ b/tests/test_track_ingest.py
@@ -415,8 +415,6 @@ def test_track_ingest_mismatch():
 
     event = {
         "collection_shortname": "SWOT_L2_HR_LakeSP_prior_2.0",
-        "hydrocron_table": "hydrocron-swot-prior-lake-table",
-        "hydrocron_track_table": "hydrocron-swot-reach-track-ingest-table",
         "temporal": "",
         "query_start": "2024-09-05T23:00:00",
         "query_end": "2024-09-05T23:59:59",


### PR DESCRIPTION
Github Issue: #267

### Description

The track ingest operations need to support new collections. This is primarily done through the creation of new tables. This will allow us to transition to the new collection (rather than re-using the old tables) and not have coordinate the removal of the tabel contents which would contain historic data for the previous collection.

### Overview of work done

- Modified `track_ingest.py` to remove table names from Lambda event as this is handled by the constants `TABLE_COLLECTION_INFO` and the collection shortname.
- Modified `track_ingest.py` to remove duplicate check for overlap between ingested and to ingest granules.
- Modified `hydrocron-eventbridge.tf` to remove extra table name input parameters in EventBridge schedule targets.
- Modified `hydrocron-dynamodb.tf` to add additional track ingest tables for version D.

### Overview of verification done

- Tested locally on version D SWOT and track ingest tables populated with data from version C to make sure track ingest operations were set up to transition to the new collection name.
- Existing unit tests pass.

### Overview of integration done

Deployed to SIT environment and checked that the new collection's track ingest tables were created correctly.

## PR checklist:

* [X] Linted
* [X] Updated unit tests
* [X] Updated changelog
* [X] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_
