### PR TITLE
Feature/issue 273 - Modify the logging of the timeseries Lambda response object to reduce the log statement size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
     - Issue 229 - Create new database tables for version d collections
     - Issue 233 - Create new API parameter for user to specify data version
+    - Issue 273 - Modify the logging of the timeseries Lambda response object to reduce the log statement size
 ### Changed
 ### Deprecated
 ### Removed

--- a/hydrocron/api/controllers/timeseries.py
+++ b/hydrocron/api/controllers/timeseries.py
@@ -497,7 +497,7 @@ def lambda_handler(event, context):  # noqa: E501 # pylint: disable=W0613
         data = get_response(results, hits, elapsed, return_type, output, parameters['compact'])
     except RequestError as e:
         raise e
-    logging.info('response: %s', json.dumps(data))
+    logging.info('response: %s', json.dumps({'status': results['http_code'], 'time': elapsed, 'hits': hits}))
     logging.info('response_size: %s', str(sys.getsizeof(data)))
 
     return data

--- a/hydrocron/db/load_data.py
+++ b/hydrocron/db/load_data.py
@@ -171,7 +171,7 @@ def cnm_handler(event, _):
         cnm = json.loads(message['Sns']['Message'])
         revision_date = cnm['submissionTime']
 
-        logging.info("Begin processing message %s", str(cnm))
+        logging.info("Begin processing message %s", json.dumps(cnm))
 
         for files in cnm['product']['files']:
             if files['type'] == 'data':


### PR DESCRIPTION
Github Issue: #273

### Description

The timeseries Lambda function logs need to be modified so that the entire response is not logged as this was causing issues with the log ingest into the Cloud Metrics platform. The logs were modified to retain the response status, time, and hits.

The timeseries Lambda function was also modified to log errors more consistently without modifying the error message sent to the end user. The errors are now logged as JSON data with the HTTP code and error message for each error type.

### Overview of work done

- Modified `timeseries.py` to remove logging of response results but retain logging of other response data.
- Modified `timeseries.py` to consistently log all types of errors with an HTTP code and error message. Existing errors returned to end user were preserved to prevent breaking changes.

### Overview of verification done

- Functionality not changed, existing unit tests pass.

### Overview of integration done

- Tested locally on all response types: geoJSON, CSV, as well as compact responses via accept headers and `compact` query parameter.
- Tested locally on all error types: Invalid accept header, missing header, invalid request query parameter, feature not found in table, unsupported media, invalid accept header with query parameter
- Deployed to SIT environment, ran tests on different response and error types, and checked that new log format could be ingested into the Cloud Metrics platform.

Sample log for response data:

```bash
[INFO] 2024-12-11T19:56:04.772Z f962762c-d639-4ed1-b9db-ff9002126d7 response: 
{
    "status": "200 OK",
    "time": 2510.143,
    "hits": 2
}
```

Sample log for error data:

```bash
[ERROR] 2024-12-11T21:39:29.608Z 562537d4-54db-450d-af6d-94eb6f9fc5e8 
{
    "http_code": 400,
    "error_message": "400: Results with the specified Feature ID 72390300017 were not found"
}
```

## PR checklist:

* [X] Linted
* [X] Updated unit tests
* [X] Updated changelog
* [X] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_
