### PR TITLE
Add version D SWOT and track ingest tables to IAM Dynamo policies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hydrocron"
-version = "1.6.0rc2"
+version = "1.6.0rc3"
 description = "OpenAPI access to Time Series data for SWOT features"
 authors = ["PO.DAAC <podaac@jpl.nasa.gov>"]
 license = "Apache-2.0"

--- a/terraform/hydrocron-iam.tf
+++ b/terraform/hydrocron-iam.tf
@@ -60,7 +60,13 @@ data "aws_iam_policy_document" "dynamo-read-policy" {
       aws_dynamodb_table.hydrocron-swot-reach-table.arn,
       "${aws_dynamodb_table.hydrocron-swot-reach-table.arn}/index/*",
       aws_dynamodb_table.hydrocron-swot-prior-lake-table.arn,
-      "${aws_dynamodb_table.hydrocron-swot-prior-lake-table.arn}/index/*"
+      "${aws_dynamodb_table.hydrocron-swot-prior-lake-table.arn}/index/*",
+      aws_dynamodb_table.hydrocron-SWOT_L2_HR_RiverSP_D-node-table.arn,
+      "${aws_dynamodb_table.hydrocron-SWOT_L2_HR_RiverSP_D-node-table.arn}/index/*",
+      aws_dynamodb_table.hydrocron-SWOT_L2_HR_RiverSP_D-reach-table.arn,
+      "${aws_dynamodb_table.hydrocron-SWOT_L2_HR_RiverSP_D-reach-table.arn}/index/*",
+      aws_dynamodb_table.hydrocron-SWOT_L2_HR_LakeSP_D-prior-lake-table.arn,
+      "${aws_dynamodb_table.hydrocron-SWOT_L2_HR_LakeSP_D-prior-lake-table.arn}/index/*"
     ]
   }
 
@@ -87,6 +93,12 @@ data "aws_iam_policy_document" "dynamo-read-policy-track-ingest" {
       "${aws_dynamodb_table.hydrocron-node-track-ingest-table.arn}/index/*",
       aws_dynamodb_table.hydrocron-priorlake-track-ingest-table.arn,
       "${aws_dynamodb_table.hydrocron-priorlake-track-ingest-table.arn}/index/*",
+      aws_dynamodb_table.hydrocron-SWOT_L2_HR_RiverSP_D-reach-track-ingest-table.arn,
+      "${aws_dynamodb_table.hydrocron-SWOT_L2_HR_RiverSP_D-reach-track-ingest-table.arn}/index/*",
+      aws_dynamodb_table.hydrocron-SWOT_L2_HR_RiverSP_D-node-track-ingest-table.arn,
+      "${aws_dynamodb_table.hydrocron-SWOT_L2_HR_RiverSP_D-node-track-ingest-table.arn}/index/*",
+      aws_dynamodb_table.hydrocron-SWOT_L2_HR_LakeSP_D-prior-lake-track-ingest-table.arn,
+      "${aws_dynamodb_table.hydrocron-SWOT_L2_HR_LakeSP_D-prior-lake-track-ingest-table.arn}/index/*"
     ]
   }
 
@@ -113,7 +125,10 @@ data "aws_iam_policy_document" "dynamo-write-policy" {
     resources = [
       aws_dynamodb_table.hydrocron-swot-node-table.arn,
       aws_dynamodb_table.hydrocron-swot-reach-table.arn,
-      aws_dynamodb_table.hydrocron-swot-prior-lake-table.arn
+      aws_dynamodb_table.hydrocron-swot-prior-lake-table.arn,
+      aws_dynamodb_table.hydrocron-SWOT_L2_HR_RiverSP_D-node-table.arn,
+      aws_dynamodb_table.hydrocron-SWOT_L2_HR_RiverSP_D-reach-table.arn,
+      aws_dynamodb_table.hydrocron-SWOT_L2_HR_LakeSP_D-prior-lake-table.arn
     ]
   }
 
@@ -141,6 +156,9 @@ data "aws_iam_policy_document" "dynamo-write-policy-track-ingest" {
       aws_dynamodb_table.hydrocron-reach-track-ingest-table.arn,
       aws_dynamodb_table.hydrocron-node-track-ingest-table.arn,
       aws_dynamodb_table.hydrocron-priorlake-track-ingest-table.arn,
+      aws_dynamodb_table.hydrocron-SWOT_L2_HR_RiverSP_D-reach-track-ingest-table.arn,
+      aws_dynamodb_table.hydrocron-SWOT_L2_HR_RiverSP_D-node-track-ingest-table.arn,
+      aws_dynamodb_table.hydrocron-SWOT_L2_HR_LakeSP_D-prior-lake-track-ingest-table.arn
     ]
   }
 


### PR DESCRIPTION
Github Issue: #270 

### Description

Modify IAM policies to include both the SWOT and track ingest Version D tables.

### Overview of work done

Updated the Terraform IAM policies for DynamoDB.

### Overview of verification done

Updates to Terraform only, no new tests added.

### Overview of integration done

No testing completed as minor update to IAM policies.

## PR checklist:

* [ ] Linted
* [ ] Updated unit tests
* [ ] Updated changelog
* [ ] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_