### PR TITLE
Make sure nodes and prior lake fields are consistent with reach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+    - Issue 254 - granuleUR field can only be returned for reaches, fails for nodes and prior lakes
 ### Security
 
 ## [1.6.1]

--- a/docs/timeseries.md
+++ b/docs/timeseries.md
@@ -143,18 +143,12 @@ Supported collection names include:
 Version C/2.0 (default):
 
 - SWOT_L2_HR_RiverSP_2.0,
-- SWOT_L2_HR_RiverSP_reach_2.0,
-- SWOT_L2_HR_RiverSP_node_2.0,
-- SWOT_L2_HR_LakeSP_2.0,
-- SWOT_L2_HR_LakeSP_prior_2.0,
+- SWOT_L2_HR_LakeSP_2.0
 
 Version D:
 
 - SWOT_L2_HR_RiverSP_D,
-- SWOT_L2_HR_RiverSP_reach_D,
-- SWOT_L2_HR_RiverSP_node_D,
-- SWOT_L2_HR_LakeSP_D,
-- SWOT_L2_HR_LakeSP_prior_D
+- SWOT_L2_HR_LakeSP_D
 
 (fields)=
 ### fields : string, required: yes

--- a/docs/user-guide/fields.md
+++ b/docs/user-guide/fields.md
@@ -61,7 +61,7 @@ Occasionally new fields may be added to the SWOT data products. If there are fie
 'area_total', 'area_tot_u', 'area_detct', 'area_det_u', 'area_wse',
 'layovr_val', 'node_dist', 'xtrk_dist',
 'flow_angle', 'node_q', 'node_q_b',
-'dark_frac', 'ice_clim_f', 'ice_dyn_f', 'partial_f', 'n_good_pix',
+'dark_frac', 'ice_clim_f', 'ice_dyn_f', 'n_good_pix',
 'xovr_cal_q', 'rdr_sig0', 'rdr_sig0_u', 'rdr_pol',
 'geoid_hght', 'solid_tide', 'load_tidef', 'load_tideg', 'pole_tide',
 'dry_trop_c', 'wet_trop_c', 'iono_c', 'xovr_cal_c',

--- a/hydrocron/utils/constants.py
+++ b/hydrocron/utils/constants.py
@@ -359,14 +359,15 @@ NODE_ALL_COLUMNS = [
     'area_total', 'area_tot_u', 'area_detct', 'area_det_u', 'area_wse',
     'layovr_val', 'node_dist', 'xtrk_dist',
     'flow_angle', 'node_q', 'node_q_b',
-    'dark_frac', 'ice_clim_f', 'ice_dyn_f', 'partial_f', 'n_good_pix',
+    'dark_frac', 'ice_clim_f', 'ice_dyn_f', 'n_good_pix',
     'xovr_cal_q', 'rdr_sig0', 'rdr_sig0_u', 'rdr_pol',
     'geoid_hght', 'solid_tide', 'load_tidef', 'load_tideg', 'pole_tide',
     'dry_trop_c', 'wet_trop_c', 'iono_c', 'xovr_cal_c',
     'p_wse', 'p_wse_var', 'p_width', 'p_wid_var', 'p_dist_out', 'p_length',
     'p_dam_id', 'p_n_ch_max', 'p_n_ch_mod',
     'cycle_id', 'pass_id', 'continent_id', 'range_start_time', 'range_end_time',
-    'crid', 'geometry', 'sword_version', 'collection_shortname', 'crid'
+    'crid', 'geometry', 'sword_version', 'collection_shortname', 'collection_version',
+    'granuleUR', 'ingest_time'
 ]
 
 PRIOR_LAKE_ALL_COLUMNS = [
@@ -380,5 +381,6 @@ PRIOR_LAKE_ALL_COLUMNS = [
     'dry_trop_c', 'wet_trop_c', 'iono_c', 'xovr_cal_c', 'lake_name', 'p_res_id',
     'p_lon', 'p_lat', 'p_ref_wse', 'p_ref_area', 'p_date_t0', 'p_ds_t0', 'p_storage',
     'cycle_id', 'pass_id', 'continent_id', 'range_start_time', 'range_end_time',
-    'crid', 'geometry', 'PLD_version', 'collection_shortname', 'crid'
+    'crid', 'geometry', 'PLD_version', 'collection_shortname', 'collection_version',
+    'granuleUR', 'ingest_time'
 ]


### PR DESCRIPTION
Github Issue: #258

### Description

The fields returned by Hydrocron queries need to be updated so they are consistent with the SWOT products and documentation. 

- The `granuleUR` field can only be returned for reaches and not nodes or prior lakes
- The `partial_f` field is not valid for nodes
- Check that `pass_id` can be retrieved for prior lakes

### Overview of work done

- Modified the `hydrocron/utils/constants.py` file to update nodes and prior lake columns so they are consistent with reaches and only retrieve available to those data products.

### Overview of verification done

- Functionality not changed, existing unit tests pass.

### Overview of integration done

- Tested locally on reaches, nodes, and prior lakes.
- Deployed to SIT and tested all fields with the following queries:

    - Reaches: https://soto.podaac.sit.earthdatacloud.nasa.gov/hydrocron/v1/timeseries?feature=Reach&feature_id=78340600051&start_time=2020-01-01T00%3A00%3A00%252b00%3A00&end_time=2025-10-30T00%3A00%3A00%252b00%3A00&fields=reach_id%2Ctime%2Ctime_tai%2Ctime_str%2Cp_lat%2Cp_lon%2Criver_name%2Cwse%2Cwse_u%2Cwse_r_u%2Cwse_c%2Cwse_c_u%2Cslope%2Cslope_u%2Cslope_r_u%2Cslope2%2Cslope2_u%2Cslope2_r_u%2Cwidth%2Cwidth_u%2Cwidth_c%2Cwidth_c_u%2Carea_total%2Carea_tot_u%2Carea_detct%2Carea_det_u%2Carea_wse%2Cd_x_area%2Cd_x_area_u%2Clayovr_val%2Cnode_dist%2Cloc_offset%2Cxtrk_dist%2Cdschg_c%2Cdschg_c_u%2Cdschg_csf%2Cdschg_c_q%2Cdschg_gc%2Cdschg_gc_u%2Cdschg_gcsf%2Cdschg_gc_q%2Cdschg_m%2Cdschg_m_u%2Cdschg_msf%2Cdschg_m_q%2Cdschg_gm%2Cdschg_gm_u%2Cdschg_gmsf%2Cdschg_gm_q%2Cdschg_b%2Cdschg_b_u%2Cdschg_bsf%2Cdschg_b_q%2Cdschg_gb%2Cdschg_gb_u%2Cdschg_gbsf%2Cdschg_gb_q%2Cdschg_h%2Cdschg_h_u%2Cdschg_hsf%2Cdschg_h_q%2Cdschg_gh%2Cdschg_gh_u%2Cdschg_ghsf%2Cdschg_gh_q%2Cdschg_o%2Cdschg_o_u%2Cdschg_osf%2Cdschg_o_q%2Cdschg_go%2Cdschg_go_u%2Cdschg_gosf%2Cdschg_go_q%2Cdschg_s%2Cdschg_s_u%2Cdschg_ssf%2Cdschg_s_q%2Cdschg_gs%2Cdschg_gs_u%2Cdschg_gssf%2Cdschg_gs_q%2Cdschg_i%2Cdschg_i_u%2Cdschg_isf%2Cdschg_i_q%2Cdschg_gi%2Cdschg_gi_u%2Cdschg_gisf%2Cdschg_gi_q%2Cdschg_q_b%2Cdschg_gq_b%2Creach_q%2Creach_q_b%2Cdark_frac%2Cice_clim_f%2Cice_dyn_f%2Cpartial_f%2Cn_good_nod%2Cobs_frac_n%2Cxovr_cal_q%2Cgeoid_hght%2Cgeoid_slop%2Csolid_tide%2Cload_tidef%2Cload_tideg%2Cpole_tide%2Cdry_trop_c%2Cwet_trop_c%2Ciono_c%2Cxovr_cal_c%2Cn_reach_up%2Cn_reach_dn%2Crch_id_up%2Crch_id_dn%2Cp_wse%2Cp_wse_var%2Cp_width%2Cp_wid_var%2Cp_n_nodes%2Cp_dist_out%2Cp_length%2Cp_maf%2Cp_dam_id%2Cp_n_ch_max%2Cp_n_ch_mod%2Cp_low_slp%2Ccycle_id%2Cpass_id%2Ccontinent_id%2Crange_start_time%2Crange_end_time%2Ccrid%2Cgeometry%2Csword_version%2Ccollection_shortname%2Ccollection_version%2CgranuleUR%2Cingest_time
    
    - Nodes: https://soto.podaac.sit.earthdatacloud.nasa.gov/hydrocron/v1/timeseries?feature=Node&feature_id=81380700310651&start_time=2020-01-01T00%3A00%3A00%252b00%3A00&end_time=2025-10-30T00%3A00%3A00%252b00%3A00&fields=reach_id%2Cnode_id%2Ctime%2Ctime_tai%2Ctime_str%2Clat%2Clon%2Clat_u%2Clon_u%2Criver_name%2Cwse%2Cwse_u%2Cwse_r_u%2Cwidth%2Cwidth_u%2Carea_total%2Carea_tot_u%2Carea_detct%2Carea_det_u%2Carea_wse%2Clayovr_val%2Cnode_dist%2Cxtrk_dist%2Cflow_angle%2Cnode_q%2Cnode_q_b%2Cdark_frac%2Cice_clim_f%2Cice_dyn_f%2Cn_good_pix%2Cxovr_cal_q%2Crdr_sig0%2Crdr_sig0_u%2Crdr_pol%2Cgeoid_hght%2Csolid_tide%2Cload_tidef%2Cload_tideg%2Cpole_tide%2Cdry_trop_c%2Cwet_trop_c%2Ciono_c%2Cxovr_cal_c%2Cp_wse%2Cp_wse_var%2Cp_width%2Cp_wid_var%2Cp_dist_out%2Cp_length%2Cp_dam_id%2Cp_n_ch_max%2Cp_n_ch_mod%2Ccycle_id%2Cpass_id%2Ccontinent_id%2Crange_start_time%2Crange_end_time%2Ccrid%2Cgeometry%2Csword_version%2Ccollection_shortname%2Ccollection_version%2CgranuleUR%2Cingest_time
    
    - Prior Lakes: https://soto.podaac.sit.earthdatacloud.nasa.gov/hydrocron/v1/timeseries?feature=PriorLake&feature_id=8310378732&start_time=2020-01-01T00%3A00%3A00%252b00%3A00&end_time=2025-10-30T00%3A00%3A00%252b00%3A00&fields=lake_id%2Creach_id%2Cobs_id%2Coverlap%2Cn_overlap%2Ctime%2Ctime_tai%2Ctime_str%2Cwse%2Cwse_u%2Cwse_r_u%2Cwse_std%2Carea_total%2Carea_tot_u%2Carea_detct%2Carea_det_u%2Clayovr_val%2Cxtrk_dist%2Cds1_l%2Cds1_l_u%2Cds1_q%2Cds1_q_u%2Cds2_l%2Cds2_l_u%2Cds2_q%2Cds2_q_u%2Cquality_f%2Cdark_frac%2Cice_clim_f%2Cice_dyn_f%2Cpartial_f%2Cxovr_cal_q%2Cgeoid_hght%2Csolid_tide%2Cload_tidef%2Cload_tideg%2Cpole_tide%2Cdry_trop_c%2Cwet_trop_c%2Ciono_c%2Cxovr_cal_c%2Clake_name%2Cp_res_id%2Cp_lon%2Cp_lat%2Cp_ref_wse%2Cp_ref_area%2Cp_date_t0%2Cp_ds_t0%2Cp_storage%2Ccycle_id%2Cpass_id%2Ccontinent_id%2Crange_start_time%2Crange_end_time%2Ccrid%2Cgeometry%2CPLD_version%2Ccollection_shortname%2Ccollection_version%2CgranuleUR%2Cingest_time

## PR checklist:

* [X] Linted
* [X] Updated unit tests
* [X] Updated changelog
* [X] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_
