### PR TITLE
Release/1.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
+## [1.6.3]
+
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+    - Issue 279 Release SWOT River Version D, track ingest collection name validation
+### Security
+
 ## [1.6.2]
 
 ### Added

--- a/hydrocron/db/track_ingest.py
+++ b/hydrocron/db/track_ingest.py
@@ -520,7 +520,11 @@ def track_ingest_handler(event, context):
     reprocessed_crid = event["reprocessed_crid"]
     temporal = "temporal" in event.keys()
 
-    parent_collection = constants.SHORTNAME[collection_shortname]
+    try:
+        parent_collection = constants.SHORTNAME[collection_shortname]
+    except KeyError as e:
+        raise TableMisMatch(f"Error: Cannot query data for collection: '{collection_shortname}'") from e
+
     for table_info in constants.TABLE_COLLECTION_INFO:
         if (table_info['collection_name'] in parent_collection) & (str.lower(table_info['feature_type']) in str.lower(collection_shortname)):
             hydrocron_table = table_info['table_name']

--- a/hydrocron/db/track_ingest.py
+++ b/hydrocron/db/track_ingest.py
@@ -522,7 +522,7 @@ def track_ingest_handler(event, context):
 
     parent_collection = constants.SHORTNAME[collection_shortname]
     for table_info in constants.TABLE_COLLECTION_INFO:
-        if (table_info['collection_name'] in parent_collection) & (str.lower(table_info['feature_type']) in collection_shortname):
+        if (table_info['collection_name'] in parent_collection) & (str.lower(table_info['feature_type']) in str.lower(collection_shortname)):
             hydrocron_table = table_info['table_name']
             hydrocron_track_table = table_info['track_table']
             break

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hydrocron"
-version = "1.7.0a0"
+version = "1.6.3rc1"
 description = "OpenAPI access to Time Series data for SWOT features"
 authors = ["PO.DAAC <podaac@jpl.nasa.gov>"]
 license = "Apache-2.0"

--- a/tests/test_track_ingest.py
+++ b/tests/test_track_ingest.py
@@ -466,7 +466,7 @@ def test_track_ingest_mismatch(track_ingest_fixture):
             self.invoked_function_arn = "arn:aws:lambda:us-west-2:12345678910:function:svc-hydrocron-sit-track-ingest-lambda"
 
     event = {
-        "collection_shortname": "SWOT_L2_HR_LakeSP_prior_2.0",
+        "collection_shortname": "SWOT_L2_HR_LakeSP_stream_2.0",
         "temporal": "",
         "query_start": "2024-09-05T23:00:00",
         "query_end": "2024-09-05T23:59:59",
@@ -475,4 +475,4 @@ def test_track_ingest_mismatch(track_ingest_fixture):
     context = LambdaContext()
     with pytest.raises(hydrocron.db.track_ingest.TableMisMatch) as e:
         hydrocron.db.track_ingest.track_ingest_handler(event, context)
-        assert str(e.value) == "Error: Cannot query prior lake data for tables: 'hydrocron-swot-prior-lake-table' and 'hydrocron-swot-reach-track-ingest-table'"
+        assert str(e.value) == "Error: Cannot query data for collection: 'SWOT_L2_HR_LakeSP_stream_2.0'"


### PR DESCRIPTION
## [1.6.3]

### Added
### Changed
### Deprecated
### Removed
### Fixed
    - Issue 279 Release SWOT River Version D, track ingest collection name validation
### Security

## Description

The track ingest Prior Lake operations failed as the collection name was being compared incorrectly to the parent collection name.

## Overview of work done

- Modified `hydrocron/db/track_ingest.py` to compare child and parent collection strings where both are lowercase and check for invalid collection name from input parameter.

## Overview of verification done

- Modified `tests/test_track_ingest.py` to test check of invalid collection name.
- All unit tests pass.

## Overview of integration done

1. Deployed to UAT environment and ran track ingest Lambda on river reaches, river nodes, and prior lakes:

reaches:

```bash
2025-05-28T20:01:22.656Z [INFO] 2025-05-28T20:01:22.656Z Located 0 granules that require ingestion.
2025-05-28T20:01:22.657Z [INFO] 2025-05-28T20:01:22.656Z Located 35 granules that are already ingested. 
2025-05-28T20:01:22.774Z [INFO] 2025-05-28T20:01:22.774Z Loaded data into table hydrocron-SWOT_L2_HR_RiverSP_D-reach-track-ingest.
2025-05-28T20:01:22.774Z [INFO] 2025-05-28T20:01:22.774Z Finished loading 35 items
2025-05-28T20:01:22.774Z [INFO] 2025-05-28T20:01:22.774Z Updated hydrocron-SWOT_L2_HR_RiverSP_D-reach-track-ingest with 35 items. 
```

nodes:

```bash
2025-05-28T19:58:12.616Z [INFO] 2025-05-28T19:58:12.616Z Located 9 granules that require ingestion.
2025-05-28T19:58:12.616Z [INFO] 2025-05-28T19:58:12.616Z Located 30 granules that are already ingested. 
2025-05-28T19:58:21.300Z [INFO] 2025-05-28T19:58:21.300Z Loaded data into table hydrocron-SWOT_L2_HR_RiverSP_D-node-track-ingest.
2025-05-28T19:58:21.300Z [INFO] 2025-05-28T19:58:21.300Z Finished loading 39 items
2025-05-28T19:58:21.300Z [INFO] 2025-05-28T19:58:21.300Z Updated hydrocron-SWOT_L2_HR_RiverSP_D-node-track-ingest with 39 items. 
```

lakes:

```bash
2025-05-28T19:55:22.412Z [INFO] 2025-05-28T19:55:22.412Z 654faa10-cf6d-406a-9636-68f955fa5d7a Located 0 granules that require ingestion.
2025-05-28T19:55:22.412Z [INFO] 2025-05-28T19:55:22.412Z 654faa10-cf6d-406a-9636-68f955fa5d7a Located 35 granules that are already ingested. 
2025-05-28T19:55:22.765Z [INFO] 2025-05-28T19:55:22.765Z Loaded data into table hydrocron-SWOT_L2_HR_LakeSP_D-prior-lake-track-ingest.
2025-05-28T19:55:22.765Z [INFO] 2025-05-28T19:55:22.765Z Finished loading 35 items
2025-05-28T19:55:22.765Z [INFO] 2025-05-28T19:55:22.765Z Updated hydrocron-SWOT_L2_HR_LakeSP_D-prior-lake-track-ingest with 35 items. 
```

## PR checklist:

* [X] Linted
* [X] Updated unit tests
* [X] Updated changelog
* [X] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_